### PR TITLE
feat: 지금 참가 가능한 여행 콘텐츠 목록

### DIFF
--- a/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
+++ b/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
@@ -3,8 +3,12 @@ package swyp.swyp6_team7;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @EnableJpaAuditing
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @SpringBootApplication
 public class Swyp6Team7Application {
 

--- a/src/main/java/swyp/swyp6_team7/global/config/QuerydslConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/QuerydslConfig.java
@@ -1,5 +1,6 @@
 package swyp.swyp6_team7.global.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,6 @@ public class QuerydslConfig {
 
     @Bean
     public JPAQueryFactory querydsl() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -1,14 +1,15 @@
 package swyp.swyp6_team7.travel.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.service.TravelHomeService;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,11 +20,12 @@ public class TravelHomeController {
 
     @GetMapping("/api/travels/recent")
     public ResponseEntity getRecentlyCreatedTravels(
-//            @RequestParam(name = "page", defaultValue = "0") int page,
-//            @RequestParam(name = "size", defaultValue = "5") int size
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "5") int size
     ) {
 
-        List<TravelRecentDto> result = travelHomeService.getTravelsSortedByCreatedAt();
+        Page<TravelRecentDto> result = travelHomeService
+                .getTravelsSortedByCreatedAt(PageRequest.of(page, size));
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(result);

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -1,0 +1,32 @@
+package swyp.swyp6_team7.travel.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.service.TravelHomeService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class TravelHomeController {
+
+    private final TravelHomeService travelHomeService;
+
+
+    @GetMapping("/api/travels/recent")
+    public ResponseEntity getRecentlyCreatedTravels(
+//            @RequestParam(name = "page", defaultValue = "0") int page,
+//            @RequestParam(name = "size", defaultValue = "5") int size
+    ) {
+
+        List<TravelRecentDto> result = travelHomeService.getTravelsSortedByCreatedAt();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(result);
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -7,10 +7,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import swyp.swyp6_team7.tag.domain.TravelTag;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Table(name = "travels")
@@ -79,6 +82,8 @@ public class Travel {
     @Column(name = "travel_status", nullable = false)
     private TravelStatus status;
 
+    @OneToMany(mappedBy = "travel")
+    private List<TravelTag> travelTags = new ArrayList<>();
 
     @Builder
     public Travel(

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TravelRecentResponse {
+public class TravelRecentDto {
 
     private static final int TAG_MAX_NUMBER = 3;
 
@@ -37,7 +37,7 @@ public class TravelRecentResponse {
 
     @Builder
     @QueryProjection
-    public TravelRecentResponse(
+    public TravelRecentDto(
             int travelNumber, String title, String summary, int userNumber, String userName,
             LocalDateTime createdAt, LocalDateTime registerDue, int maxPerson, int nowPerson,
             List<String> tags) {
@@ -54,7 +54,7 @@ public class TravelRecentResponse {
     }
 
 
-    public TravelRecentResponse(Travel travel, List<Tag> tags) {
+    public TravelRecentDto(Travel travel, List<Tag> tags) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
         this.summary = travel.getSummary();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentResponse.java
@@ -1,0 +1,50 @@
+package swyp.swyp6_team7.travel.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TravelRecentResponse {
+
+    @NotNull
+    private int travelNumber;
+    private String title;
+    private String summary;
+    private int userNumber;
+    private String userName;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd일")
+    private LocalDateTime registerDue;
+    private int maxPerson;
+    private int nowPerson;
+    private List<String> tags;
+    //TODO: 이미지
+
+
+    @Builder
+    public TravelRecentResponse(
+            int travelNumber, String title, String summary, int userNumber, String userName,
+            LocalDateTime createdAt, LocalDateTime registerDue, int maxPerson, int nowPerson,
+            List<String> tags) {
+        this.travelNumber = travelNumber;
+        this.title = title;
+        this.summary = summary;
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.createdAt = createdAt;
+        this.registerDue = registerDue;
+        this.maxPerson = maxPerson;
+        this.nowPerson = nowPerson;
+        this.tags = tags;
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentResponse.java
@@ -1,11 +1,14 @@
 package swyp.swyp6_team7.travel.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +16,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TravelRecentResponse {
+
+    private static final int TAG_MAX_NUMBER = 3;
 
     @NotNull
     private int travelNumber;
@@ -22,7 +27,7 @@ public class TravelRecentResponse {
     private String userName;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDateTime registerDue;
     private int maxPerson;
     private int nowPerson;
@@ -31,6 +36,7 @@ public class TravelRecentResponse {
 
 
     @Builder
+    @QueryProjection
     public TravelRecentResponse(
             int travelNumber, String title, String summary, int userNumber, String userName,
             LocalDateTime createdAt, LocalDateTime registerDue, int maxPerson, int nowPerson,
@@ -47,4 +53,40 @@ public class TravelRecentResponse {
         this.tags = tags;
     }
 
+
+    public TravelRecentResponse(Travel travel, List<Tag> tags) {
+        this.travelNumber = travel.getNumber();
+        this.title = travel.getTitle();
+        this.summary = travel.getSummary();
+        this.userNumber = travel.getUserNumber();
+        this.userName = "testuser"; //todo
+        this.createdAt = travel.getCreatedAt();
+        this.registerDue = travel.getDueDateTime();
+        this.maxPerson = travel.getMaxPerson();
+        this.nowPerson = 1; //todo
+        this.tags = convertToTagNames(tags);
+    }
+
+    private List<String> convertToTagNames(List<Tag> tags) {
+        return tags.stream()
+                .limit(TAG_MAX_NUMBER)
+                .map(tag -> tag.getName())
+                .toList();
+    }
+
+    @Override
+    public String toString() {
+        return "TravelRecentResponse{" +
+                "travelNumber=" + travelNumber +
+                ", title='" + title + '\'' +
+                ", summary='" + summary + '\'' +
+                ", userNumber=" + userNumber +
+                ", userName='" + userName + '\'' +
+                ", createdAt=" + createdAt +
+                ", registerDue=" + registerDue +
+                ", maxPerson=" + maxPerson +
+                ", nowPerson=" + nowPerson +
+                ", tags=" + tags +
+                '}';
+    }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -3,8 +3,13 @@ package swyp.swyp6_team7.travel.repository;
 import org.springframework.data.domain.Page;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+
+import java.util.List;
 
 public interface TravelCustomRepository {
+
+    List<TravelRecentDto> findAllSortedByCreatedAt();
 
     Page<Travel> search(TravelSearchCondition condition);
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -1,15 +1,14 @@
 package swyp.swyp6_team7.travel.repository;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 
-import java.util.List;
-
 public interface TravelCustomRepository {
 
-    List<TravelRecentDto> findAllSortedByCreatedAt();
+    Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest);
 
     Page<Travel> search(TravelSearchCondition condition);
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package swyp.swyp6_team7.travel.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -14,8 +15,12 @@ import swyp.swyp6_team7.travel.domain.QTravel;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 
 import java.util.List;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
 
 @Slf4j
 @Repository
@@ -30,6 +35,26 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
     QTravel travel = QTravel.travel;
     QTag tag = QTag.tag;
     QTravelTag travelTag = QTravelTag.travelTag;
+
+
+    @Override
+    public List<TravelRecentDto> findAllSortedByCreatedAt() {
+
+        List<TravelRecentDto> content = queryFactory
+                .select(travel)
+                .from(travel)
+                .leftJoin(travel.travelTags, travelTag)
+                .leftJoin(travelTag.tag, tag)
+                .where(
+                        statusActivated()
+                )
+                .orderBy(travel.createdAt.desc())
+                .transform(groupBy(travel.number).list(
+                        Projections.constructor(TravelRecentDto.class,
+                                travel, list(tag)))
+                );
+        return content;
+    }
 
 
     @Override

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
@@ -1,0 +1,22 @@
+package swyp.swyp6_team7.travel.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TravelHomeService {
+
+    private final TravelRepository travelRepository;
+
+    public List<TravelRecentDto> getTravelsSortedByCreatedAt() {
+        return travelRepository.findAllSortedByCreatedAt();
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
@@ -1,12 +1,12 @@
 package swyp.swyp6_team7.travel.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -15,8 +15,8 @@ public class TravelHomeService {
 
     private final TravelRepository travelRepository;
 
-    public List<TravelRecentDto> getTravelsSortedByCreatedAt() {
-        return travelRepository.findAllSortedByCreatedAt();
+    public Page<TravelRecentDto> getTravelsSortedByCreatedAt(PageRequest pageRequest) {
+        return travelRepository.findAllSortedByCreatedAt(pageRequest);
     }
 
 }

--- a/src/test/java/swyp/swyp6_team7/config/DataConfig.java
+++ b/src/test/java/swyp/swyp6_team7/config/DataConfig.java
@@ -1,5 +1,6 @@
 package swyp.swyp6_team7.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -14,6 +15,6 @@ public class DataConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -64,12 +64,13 @@ class TravelCustomRepositoryImplTest {
         }
 
         // when
-        List<TravelRecentDto> results = travelRepository.findAllSortedByCreatedAt();
+        Page<TravelRecentDto> results = travelRepository
+                .findAllSortedByCreatedAt(PageRequest.of(0, 5));
 
         // then
-        assertThat(results.size()).isEqualTo(2);
-        assertThat(results.get(0).getTitle()).isEqualTo("추가 테스트 데이터");
-        assertThat(results.get(0).getTags().size()).isEqualTo(3);
+        assertThat(results.getContent().size()).isEqualTo(2);
+        assertThat(results.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터");
+        assertThat(results.getContent().get(0).getTags().size()).isEqualTo(3);
     }
 
     @DisplayName("search: 제목에 keyword가 포함된 데이터를 찾을 수 있다")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -19,7 +19,6 @@ import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,9 +67,29 @@ class TravelCustomRepositoryImplTest {
                 .findAllSortedByCreatedAt(PageRequest.of(0, 5));
 
         // then
+        for (TravelRecentDto result : results) {
+            System.out.println(result.toString());
+        }
         assertThat(results.getContent().size()).isEqualTo(2);
         assertThat(results.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터");
         assertThat(results.getContent().get(0).getTags().size()).isEqualTo(3);
+    }
+
+    @DisplayName("findAll: 최신순으로 정렬해 반환할 때 데이터가 없을 경우에도 오류가 나지 않는다")
+    @Test
+    public void findAllSortedByCreatedAtNoData() {
+        // given
+        travelRepository.deleteAll();
+
+        // when
+        Page<TravelRecentDto> results = travelRepository
+                .findAllSortedByCreatedAt(PageRequest.of(0, 5));
+
+        // then
+        for (TravelRecentDto result : results) {
+            System.out.println(result.toString());
+        }
+        assertThat(results.getContent().size()).isEqualTo(0);
     }
 
     @DisplayName("search: 제목에 keyword가 포함된 데이터를 찾을 수 있다")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -69,7 +69,7 @@ class TravelCustomRepositoryImplTest {
         // then
         assertThat(results.size()).isEqualTo(2);
         assertThat(results.get(0).getTitle()).isEqualTo("추가 테스트 데이터");
-        assertThat(results.get(0).getTags().size()).isEqualTo(5);
+        assertThat(results.get(0).getTags().size()).isEqualTo(3);
     }
 
     @DisplayName("search: 제목에 keyword가 포함된 데이터를 찾을 수 있다")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -16,7 +16,7 @@ import swyp.swyp6_team7.tag.repository.TravelTagRepository;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
-import swyp.swyp6_team7.travel.dto.response.TravelRecentResponse;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -64,7 +64,7 @@ class TravelCustomRepositoryImplTest {
         }
 
         // when
-        List<TravelRecentResponse> results = travelRepository.findAllSortedByCreatedAt();
+        List<TravelRecentDto> results = travelRepository.findAllSortedByCreatedAt();
 
         // then
         assertThat(results.size()).isEqualTo(2);

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -16,10 +16,9 @@ import swyp.swyp6_team7.tag.repository.TravelTagRepository;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
-import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentResponse;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +44,32 @@ class TravelCustomRepositoryImplTest {
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build());
+    }
+
+    @DisplayName("findAll: 여행 콘텐츠를 DTO로 만들어 최신순으로 정렬해 반환한다")
+    @Test
+    public void findAllSortedByCreatedAt() {
+        // given
+        Travel travel = Travel.builder()
+                .title("추가 테스트 데이터")
+                .userNumber(1)
+                .viewCount(0)
+                .createdAt(LocalDateTime.now().plusDays(1))
+                .status(TravelStatus.IN_PROGRESS)
+                .build();
+        travelRepository.save(travel);
+        for (int i = 0; i < 5; i++) {
+            Tag tag = tagRepository.save(Tag.of("태그" + i));
+            travelTagRepository.save(TravelTag.of(travel, tag));
+        }
+
+        // when
+        List<TravelRecentResponse> results = travelRepository.findAllSortedByCreatedAt();
+
+        // then
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getTitle()).isEqualTo("추가 테스트 데이터");
+        assertThat(results.get(0).getTags().size()).isEqualTo(5);
     }
 
     @DisplayName("search: 제목에 keyword가 포함된 데이터를 찾을 수 있다")


### PR DESCRIPTION
## 🔗 Issue Number
feat: 지금 참가 가능한 여행 콘텐츠 #9

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
* 최근 발행된 여행 콘텐츠 목록을 페이징해서 가져오는 기능 및 api 구현
* Qurydsl의 transform과 페이징을 함께 적용하니 오류가 발생하는 문제가 있었다.
* 콘텐츠에 태그가 여러 개 달린 경우 페이징 할 때는 여러 개의 데이터라고 판단되지만, 전송할 때에는 group으로 묶기 때문에 발생하는 문제라고 파악했다.
* 우선 전달한 여행 콘텐츠 식별자 리스트를 먼저 생성하고, 해당 식별자에 대해 join 등을 사용해 데이터를 만드는 방식으로 구현했다. -> 추후 시간이 남을 경우 보완 및 리팩토링 할 예정


## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
