### PR TITLE
feat: 여행 콘텐츠 검색 - 태그 필터링

### DIFF
--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -1,37 +1,24 @@
 package swyp.swyp6_team7.travel.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.domain.PageRequest;
 
-import java.awt.print.Pageable;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Getter
 public class TravelSearchCondition {
 
     private String keyword;
     private PageRequest pageRequest;
-    private List<String> tags;
-    //태그 -> and, 완전 일치
+    @Builder.Default
+    private List<String> tags = new ArrayList<>();
     //장소 -> 국내, 해외
     //인원 -> 
     //기간 -> 일주일 이하, 1~4주, 한달 이상
     //정렬 -> 추천순, 최신순, 등록일순, 정확도순
-
-
-    @Builder
-    public TravelSearchCondition(
-            String keyword,
-            PageRequest pageRequest,
-            List<String> tags
-    ) {
-        this.keyword = keyword;
-        this.pageRequest = pageRequest;
-        this.tags = tags;
-    }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.domain.TravelStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,12 +15,14 @@ import java.util.List;
 @Getter
 public class TravelSearchDto {
 
+    private static final int TAG_MAX_NUMBER = 3;
+
     private int travelNumber;
     private String title;
     private int userNumber;
     private String userName;
     private List<String> tags;
-    //private int nowPerson;
+    private int nowPerson;
     private int maxPerson;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDateTime createdAt;
@@ -32,16 +33,16 @@ public class TravelSearchDto {
 
     @Builder
     public TravelSearchDto(
-            int travelNumber, String title,  int userNumber,  //String userName,
-            List<String> tags, int maxPerson,
+            int travelNumber, String title, int userNumber, String userName,
+            List<String> tags, int maxPerson, int nowPerson,
             LocalDateTime createdAt, LocalDateTime registerDue, String postStatus
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
         this.userNumber = userNumber;
-        //this.userName = userName;
+        this.userName = userName;
         this.tags = tags;
-        //현재 인원
+        this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
         this.registerDue = registerDue;
@@ -50,34 +51,19 @@ public class TravelSearchDto {
 
     @QueryProjection
     public TravelSearchDto(
-            int travelNumber, String title,  int userNumber,  //String userName,
-            List<String> tags, int maxPerson,
-            LocalDateTime createdAt, LocalDateTime registerDue, TravelStatus postStatus
+            Travel travel,
+            List<String> tags
     ) {
-        this.travelNumber = travelNumber;
-        this.title = title;
-        this.userNumber = userNumber;
-        //this.userName = userName;
-        this.tags = tags;
-        //현재 인원
-        this.maxPerson = maxPerson;
-        this.createdAt = createdAt;
-        this.registerDue = registerDue;
-        this.postStatus = postStatus.getName();
-    }
-
-    public static TravelSearchDto from(Travel travel) {
-        return TravelSearchDto.builder()
-                .travelNumber(travel.getNumber())
-                .title(travel.getTitle())
-                .userNumber(travel.getUserNumber())
-                //.userName(travel.getuserNam)
-                //.tags(tags)
-                .maxPerson(travel.getMaxPerson())
-                .createdAt(travel.getCreatedAt())
-                .registerDue(travel.getDueDateTime())
-                .postStatus(travel.getStatus().getName())
-                .build();
+        this.travelNumber = travel.getNumber();
+        this.title = travel.getTitle();
+        this.userNumber = travel.getUserNumber();
+        this.userName = "testuser";
+        this.tags = tags.stream().limit(TAG_MAX_NUMBER).toList();
+        this.nowPerson = 1;
+        this.maxPerson = travel.getMaxPerson();
+        this.createdAt = travel.getCreatedAt();
+        this.registerDue = travel.getDueDateTime();
+        this.postStatus = travel.getStatus().getName();
     }
 
     @Override
@@ -88,6 +74,11 @@ public class TravelSearchDto {
                 ", userNumber=" + userNumber +
                 ", userName='" + userName + '\'' +
                 ", tags=" + tags +
+                ", nowPerson=" + nowPerson +
+                ", maxPerson=" + maxPerson +
+                ", createdAt=" + createdAt +
+                ", registerDue=" + registerDue +
+                ", postStatus='" + postStatus + '\'' +
                 '}';
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -2,14 +2,14 @@ package swyp.swyp6_team7.travel.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 
 public interface TravelCustomRepository {
 
     Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest);
 
-    Page<Travel> search(TravelSearchCondition condition);
+    Page<TravelSearchDto> search(TravelSearchCondition condition);
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -71,8 +71,7 @@ public class TravelService {
 
 
     public Page<TravelSearchDto> search(TravelSearchCondition condition) {
-        Page<TravelSearchDto> result = travelRepository.search(condition)
-                .map(TravelSearchDto::from);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
         for (TravelSearchDto travelSearchDto : result) {
             log.info("service: " + travelSearchDto.toString());
         }

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -17,8 +17,11 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -111,10 +114,11 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<Travel> results = travelRepository.search(condition);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent().size()).isEqualTo(1);
     }
 
     @DisplayName("search: 키워드가 주어지지 않을 경우 가능한 모든 콘텐츠를 전달")
@@ -131,15 +135,16 @@ class TravelCustomRepositoryImplTest {
         travelRepository.save(travel);
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword("")
+                //.keyword("")
                 .pageRequest(PageRequest.of(0, 5))
                 .build();
 
         // when
-        Page<Travel> results = travelRepository.search(condition);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getTotalElements()).isEqualTo(2);
+        assertThat(results.getContent().size()).isEqualTo(2);
     }
 
     @DisplayName("search: 콘텐츠의 상태가 DELETED, DRAFT일 경우 제외하고 가져온다")
@@ -169,10 +174,11 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<Travel> results = travelRepository.search(condition);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent().size()).isEqualTo(1);
     }
 
     @DisplayName("search: 페이징을 이용해 콘텐츠를 가져올 수 있다")
@@ -195,87 +201,92 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<Travel> result = travelRepository.search(condition);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
 
         // then
         assertThat(result.getTotalPages()).isEqualTo(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
+        assertThat(result.getContent().size()).isEqualTo(5);
     }
 
-//    @DisplayName("search: 주어지는 태그가 달린 콘텐츠를 가져온다")
-//    @Test
-//    public void searchWithTags() {
-//        // given
-//        Tag tag = tagRepository.save(Tag.of("테스트"));
-//        for (int i = 0; i < 6; i++) {
-//            Travel travel = travelRepository.save(Travel.builder()
-//                    .title("추가 테스트 데이터" + i)
-//                    .userNumber(1)
-//                    .viewCount(0)
-//                    .createdAt(LocalDateTime.now())
-//                    .status(TravelStatus.IN_PROGRESS)
-//                    .build());
-//            travelTagRepository.save(TravelTag.of(travel, tag));
-//        }
-//
-//        List<String> tags = new ArrayList<>();
-//        tags.add("테스트");
-//        TravelSearchCondition condition = TravelSearchCondition.builder()
-//                .pageRequest(PageRequest.of(0, 5))
-//                .tags(tags)
-//                .build();
-//
-//        // when
-//        Page<Travel> result = travelRepository.search(condition);
-//
-//        // then
-//        Page<TravelSearchDto> temp = travelRepository.search(condition)
-//                .map(TravelSearchDto::from);
-//        for (TravelSearchDto travelSearchDto : temp) {
-//            System.out.println(travelSearchDto.toString());
-//        }
-//        assertThat(result.getTotalElements()).isEqualTo(6);
-//    }
-//
-//    @DisplayName("search: 여러 개의 태그가 주어졌을 때, 모든 태그를 가진 콘텐츠만 가져온다")
-//    @Test
-//    public void searchWithMultipleTags() {
-//        // given
-//        Tag tag1 = tagRepository.save(Tag.of("한국"));
-//        Tag tag2 = tagRepository.save(Tag.of("투어"));
-//
-//        Travel travel1 = travelRepository.save(Travel.builder()
-//                .title("추가 테스트 데이터1")
-//                .userNumber(1)
-//                .viewCount(0)
-//                .createdAt(LocalDateTime.now())
-//                .status(TravelStatus.IN_PROGRESS)
-//                .build());
-//        travelTagRepository.save(TravelTag.of(travel1, tag1));
-//        travelTagRepository.save(TravelTag.of(travel1, tag2));
-//
-//        Travel travel2 = travelRepository.save(Travel.builder()
-//                .title("추가 테스트 데이터2")
-//                .userNumber(1)
-//                .viewCount(0)
-//                .createdAt(LocalDateTime.now())
-//                .status(TravelStatus.IN_PROGRESS)
-//                .build());
-//        travelTagRepository.save(TravelTag.of(travel2, tag1));
-//
-//        List<String> tags = new ArrayList<>();
-//        tags.add("한국");
-//        tags.add("투어");
-//        TravelSearchCondition condition = TravelSearchCondition.builder()
-//                .pageRequest(PageRequest.of(0, 5))
-//                .tags(tags)
-//                .build();
-//
-//        // when
-//        Page<Travel> result = travelRepository.search(condition);
-//
-//        // then
-//        assertThat(result.getTotalElements()).isEqualTo(1);
-//    }
+    @DisplayName("search: 주어지는 태그가 달린 콘텐츠를 가져온다")
+    @Test
+    public void searchWithTags() {
+        // given
+        Tag tag = tagRepository.save(Tag.of("테스트"));
+        for (int i = 0; i < 6; i++) {
+            Travel travel = travelRepository.save(Travel.builder()
+                    .title("추가 테스트 데이터" + i)
+                    .userNumber(1)
+                    .viewCount(0)
+                    .createdAt(LocalDateTime.now())
+                    .status(TravelStatus.IN_PROGRESS)
+                    .build());
+            travelTagRepository.save(TravelTag.of(travel, tag));
+        }
+
+        List<String> tags = new ArrayList<>();
+        tags.add("테스트");
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .tags(tags)
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // then;
+        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(6);
+        assertThat(result.getContent().size()).isEqualTo(5);
+    }
+
+    @DisplayName("search: 여러 개의 태그가 주어졌을 때, 모든 태그를 가진 콘텐츠만 가져온다")
+    @Test
+    public void searchWithMultipleTags() {
+        // given
+        Tag tag1 = tagRepository.save(Tag.of("한국"));
+        Tag tag2 = tagRepository.save(Tag.of("투어"));
+        Tag tag3 = tagRepository.save(Tag.of("도시"));
+
+        Travel travel1 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터1")
+                .userNumber(1)
+                .viewCount(0)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        //tags: 한국, 도시
+        travelTagRepository.save(TravelTag.of(travel1, tag1));
+        travelTagRepository.save(TravelTag.of(travel1, tag3));
+
+        Travel travel2 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터2")
+                .userNumber(1)
+                .viewCount(0)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        //tags: 한국, 투어
+        travelTagRepository.save(TravelTag.of(travel2, tag1));
+        travelTagRepository.save(TravelTag.of(travel2, tag2));
+
+        List<String> tags = new ArrayList<>();
+        tags.add("한국");
+        tags.add("투어");
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .tags(tags)
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // then
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().size()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터2");
+    }
 
 }


### PR DESCRIPTION
## 🔗 Issue Number

feat: 여행 콘텐츠 검색 기능 태그 필터링 #13

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행 콘텐츠를 검색하는 기능에 태그 필터링 로직을 추가함
* TravelCustomRepository의 search 메서드 반환값을 TravelSearchDto로 수정
* TravelSearchDto의 from 메서드 삭제
* TravelSearchCondition의 Builder를 클래스 레벨로 지정 후 tags 디폴트값 설정
* TravelCustomRepositoryImpl search 메서드 로직 수정
  * where 절에 eqTags 추가, having 절로 모든 태그 존재 여부 확인
  * 태그 필터링 테스트코드 추가


## 🔖 리뷰 요구사항(선택)

.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
