### PR TITLE
feat: Travel 도메인 및 기획 변경 사항 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'//OAuth2

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -16,6 +16,7 @@ import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.service.TravelService;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -67,9 +68,9 @@ public class TravelController {
     ) {
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword(keyword)
                 .pageRequest(PageRequest.of(page, size))
-                .tags(tags)
+                .keyword(keyword)
+                .tags(tags == null ? new ArrayList<>() : tags)
                 .build();
         log.info("search tags: " + condition.getTags());
 

--- a/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum GenderType {
 
-    MIXED("혼성"),
+    MIXED("모두"),
     WOMAN_ONLY("여자만"),
     MAN_ONLY("남자만"),
     NONE("없음");

--- a/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
@@ -1,0 +1,16 @@
+package swyp.swyp6_team7.travel.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenderType {
+
+    MIXED("혼성"),
+    WOMAN_ONLY("여자만"),
+    MAN_ONLY("남자만");
+
+    private final String name;
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/GenderType.java
@@ -3,14 +3,29 @@ package swyp.swyp6_team7.travel.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum GenderType {
 
     MIXED("혼성"),
     WOMAN_ONLY("여자만"),
-    MAN_ONLY("남자만");
+    MAN_ONLY("남자만"),
+    NONE("없음");
 
-    private final String name;
+    private final String description;
+
+    public static GenderType of(String type) {
+        return Arrays.stream(values())
+                .filter(e -> e.description.equals(type))
+                .findFirst()
+                .orElse(NONE);
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/domain/PeriodType.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/PeriodType.java
@@ -3,6 +3,8 @@ package swyp.swyp6_team7.travel.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum PeriodType {
@@ -10,9 +12,17 @@ public enum PeriodType {
     ONE_WEEK("일주일 이하"),
     TWO_WEEKS("1~2주"),
     THREE_WEEKS("3~4주"),
-    MORE_THAN_MONTH("한 달 이상");
+    MORE_THAN_MONTH("한 달 이상"),
+    NONE("없음");
 
     private final String description;
+
+    public static PeriodType of(String type) {
+        return Arrays.stream(values())
+                .filter(e -> e.description.equals(type))
+                .findFirst()
+                .orElse(NONE);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/swyp/swyp6_team7/travel/domain/PeriodType.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/PeriodType.java
@@ -1,0 +1,22 @@
+package swyp.swyp6_team7.travel.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PeriodType {
+
+    ONE_WEEK("일주일 이하"),
+    TWO_WEEKS("1~2주"),
+    THREE_WEEKS("3~4주"),
+    MORE_THAN_MONTH("한 달 이상");
+
+    private final String description;
+
+    @Override
+    public String toString() {
+        return description;
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -58,7 +58,8 @@ public class Travel {
     private int maxPerson;
 
     //모집 성별 카테고리
-    @Column(name = "travel_gender", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "travel_gender", nullable = false, length = 20)
     private GenderType genderType;
 
     //모집 종료 일시
@@ -66,6 +67,7 @@ public class Travel {
     private LocalDate dueDate;
 
     //여행 기간 카테고리
+    @Enumerated(EnumType.STRING)
     @Column(name = "travel_period", nullable = false, length = 20)
     private PeriodType periodType;
 

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -58,7 +58,7 @@ public class Travel {
     private int maxPerson;
 
     //모집 성별 카테고리
-    @Column(name = "travel_gender_type", nullable = false)
+    @Column(name = "travel_gender", nullable = false)
     private GenderType genderType;
 
     //모집 종료 일시

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -27,15 +27,24 @@ public class Travel {
     @Column(name = "travel_number", updatable = false)
     private int number;
 
+    //작성자 식별자
     @Column(name = "user_number", nullable = false)
     private int userNumber;
 
+    //작성 일시
+    @CreatedDate
+    @Column(name = "travel_reg_date", nullable = false)
+    private LocalDateTime createdAt;
+
+    //여행지
+    @Column(name = "travel_location", length = 20)
+    private String location;
+
+    //제목
     @Column(name = "travel_title", length = 20)
     private String title;
 
-    @Column(name = "travel_summary", length = 30)
-    private String summary;
-
+    //상세 설명
     @Lob
     @Column(name = "travel_details", length = 2000)
     private String details;
@@ -44,42 +53,25 @@ public class Travel {
     @Column(name = "view_count", nullable = false)
     private int viewCount;
 
-    //작성 일시
-    @CreatedDate
-    @Column(name = "travel_reg_date", nullable = false)
-    private LocalDateTime createdAt;
-
-    //여행 시작 날짜
-    @Column(name = "travel_start_at")
-    private LocalDate startAt;
-
-    //여행 종료 날짜
-    @Column(name = "travel_end_at")
-    private LocalDate endAt;
-
-    //모집 종료 일시(날짜+시간)
-    @Column(name = "travel_due_datetime")
-    private LocalDateTime dueDateTime;
-
-    //여행지
-    @Column(name = "travel_location", length = 20)
-    private String location;
-
-    //모집 최소 인원
-    @Column(name = "travel_min_person")
-    private int minPerson;
-
-    //모집 최대 인원
+    //최대 모집 인원
     @Column(name = "travel_max_person")
     private int maxPerson;
 
-    //예산
-    @Column(name = "travel_budget")
-    private int budget;
+    //모집 성별 카테고리
+    @Column(name = "travel_gender_type", nullable = false)
+    private GenderType genderType;
 
-    //TODO: StatusConverter 사용 고민
+    //모집 종료 일시
+    @Column(name = "travel_due_date")
+    private LocalDate dueDate;
+
+    //여행 기간 카테고리
+    @Column(name = "travel_period", nullable = false, length = 20)
+    private PeriodType periodType;
+
+    //콘텐츠 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "travel_status", nullable = false)
+    @Column(name = "travel_status", nullable = false, length = 20)
     private TravelStatus status;
 
     @OneToMany(mappedBy = "travel")
@@ -87,43 +79,56 @@ public class Travel {
 
     @Builder
     public Travel(
-            int number, int userNumber, String title, String summary, String details, int viewCount,
-            LocalDateTime createdAt, LocalDate startAt, LocalDate endAt, LocalDateTime dueDateTime,
-            String location, int minPerson, int maxPerson, int budget, TravelStatus status
+            int number, int userNumber, LocalDateTime createdAt,
+            String location, String title, String details, int viewCount,
+            int maxPerson, GenderType genderType, LocalDate dueDate,
+            PeriodType periodType, TravelStatus status
     ) {
         this.number = number;
         this.userNumber = userNumber;
+        this.createdAt = createdAt;
+        this.location = location;
         this.title = title;
-        this.summary = summary;
         this.details = details;
         this.viewCount = viewCount;
-        this.createdAt = createdAt;
-        this.startAt = startAt;
-        this.endAt = endAt;
-        this.dueDateTime = dueDateTime;
-        this.location = location;
-        this.minPerson = minPerson;
         this.maxPerson = maxPerson;
-        this.budget = budget;
+        this.genderType = genderType;
+        this.dueDate = dueDate;
+        this.periodType = periodType;
         this.status = status;
     }
 
     public Travel update(TravelUpdateRequest travelUpdate) {
-        this.title = travelUpdate.getTitle();
-        this.summary = travelUpdate.getSummary();
-        this.details = travelUpdate.getDetails();
-        this.startAt = travelUpdate.getTravelStartAt();
-        this.endAt = travelUpdate.getTravelEndAt();
-        this.dueDateTime = travelUpdate.getDueDateTime();
         this.location = travelUpdate.getLocation();
-        this.minPerson = travelUpdate.getMinPerson();
+        this.title = travelUpdate.getTitle();
+        this.details = travelUpdate.getDetails();
         this.maxPerson = travelUpdate.getMaxPerson();
-        this.budget = travelUpdate.getBudget();
+        this.genderType = GenderType.of(travelUpdate.getGenderType());
+        this.dueDate = travelUpdate.getDueDate();
+        this.periodType = PeriodType.of(travelUpdate.getPeriodType());
         this.status = TravelStatus.convertCompletionToStatus(travelUpdate.getCompletionStatus());
         return this;
     }
 
     public void delete() {
         this.status = TravelStatus.DELETED;
+    }
+
+    @Override
+    public String toString() {
+        return "Travel{" +
+                "number=" + number +
+                ", userNumber=" + userNumber +
+                ", createdAt=" + createdAt +
+                ", location='" + location + '\'' +
+                ", title='" + title + '\'' +
+                ", details='" + details + '\'' +
+                ", viewCount=" + viewCount +
+                ", maxPerson=" + maxPerson +
+                ", genderType=" + genderType +
+                ", dueDate=" + dueDate +
+                ", periodType=" + periodType +
+                ", status=" + status +
+                '}';
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
@@ -11,14 +11,18 @@ public enum TravelStatus {
     CLOSED("모집 종료"),
     DELETED("삭제");
 
-
     private final String name;
 
-    public static TravelStatus convertCompletionToStatus(boolean completion){
+    public static TravelStatus convertCompletionToStatus(boolean completion) {
         if (completion == true) {
             return TravelStatus.IN_PROGRESS;
         } else {
             return TravelStatus.DRAFT;
         }
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
@@ -13,7 +13,7 @@ public enum TravelStatus {
 
     private final String name;
 
-    public static TravelStatus convertCompletionToStatus(boolean completion) {
+    public static TravelStatus convertCompletionToStatus(boolean completion){
         if (completion == true) {
             return TravelStatus.IN_PROGRESS;
         } else {
@@ -25,4 +25,5 @@ public enum TravelStatus {
     public String toString() {
         return name;
     }
+
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -1,24 +1,33 @@
 package swyp.swyp6_team7.travel.dto;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Getter
 public class TravelSearchCondition {
 
-    private String keyword;
     private PageRequest pageRequest;
-    @Builder.Default
-    private List<String> tags = new ArrayList<>();
+    private String keyword;
+    private List<String> tags;
+
     //장소 -> 국내, 해외
-    //인원 -> 
-    //기간 -> 일주일 이하, 1~4주, 한달 이상
+    //인원 -> maxPerson
+    //성별 -> GenderType
+    //기간 -> PeriodType
     //정렬 -> 추천순, 최신순, 등록일순, 정확도순
+
+
+    @Builder
+    public TravelSearchCondition(PageRequest pageRequest, String keyword, List<String> tags) {
+        this.pageRequest = pageRequest;
+        this.keyword = keyword;
+        this.tags = tags;
+    }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
@@ -1,15 +1,19 @@
 package swyp.swyp6_team7.travel.dto.request;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,57 +23,50 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TravelCreateRequest {
 
-    private String title;
-    private String summary;
-    @NotNull @Builder.Default
-    private List<String> tags = new ArrayList<>();
-    private String details;
-    private LocalDateTime dueDateTime;
-    private LocalDate travelStartAt;
-    private LocalDate travelEndAt;
     private String location;
-    private int minPerson;
+    @Size(max = 20)
+    private String title;
+    private String details;
+    @PositiveOrZero
     private int maxPerson;
-    private int budget;
+    private String genderType;
+    @FutureOrPresent
+    private LocalDate dueDate;
+    private String periodType;
+    @NotNull
+    @Builder.Default
+    private List<String> tags = new ArrayList<>();
     @NotNull
     private boolean completionStatus;
 
 
-    //@Builder
     public TravelCreateRequest(
-            String title, String summary, List<String> tags, String details,
-            LocalDateTime dueDateTime, LocalDate travelStartAt, LocalDate travelEndAt,
-            String location, int minPerson, int maxPerson, int budget, boolean completionStatus
+            String location, String title, String details,
+            int maxPerson, String genderType, LocalDate dueDate, String periodType,
+            List<String> tags, boolean completionStatus
     ) {
-        this.title = title;
-        this.summary = summary;
-        this.tags = tags;
-        this.details = details;
-        this.dueDateTime = dueDateTime;
-        this.travelStartAt = travelStartAt;
-        this.travelEndAt = travelEndAt;
         this.location = location;
-        this.minPerson = minPerson;
+        this.title = title;
+        this.details = details;
         this.maxPerson = maxPerson;
-        this.budget = budget;
+        this.genderType = genderType;
+        this.dueDate = dueDate;
+        this.periodType = periodType;
+        this.tags = tags;
         this.completionStatus = completionStatus;
     }
-
 
     public Travel toTravelEntity(int userNumber) {
         return Travel.builder()
                 .userNumber(userNumber)
+                .location(location)
                 .title(title)
-                .summary(summary)
                 .details(details)
                 .viewCount(0)
-                .startAt(travelStartAt)
-                .endAt(travelEndAt)
-                .dueDateTime(dueDateTime)
-                .location(location)
-                .minPerson(minPerson)
                 .maxPerson(maxPerson)
-                .budget(budget)
+                .genderType(GenderType.of(genderType))
+                .dueDate(dueDate)
+                .periodType(PeriodType.of(periodType))
                 .status(TravelStatus.convertCompletionToStatus(completionStatus))
                 .build();
     }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
@@ -1,10 +1,12 @@
 package swyp.swyp6_team7.travel.dto.request;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,19 +16,19 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TravelUpdateRequest {
 
+    private String location;
+    @Size(max = 20)
     private String title;
-    private String summary;
+    private String details;
+    @PositiveOrZero
+    private int maxPerson;
+    private String genderType;
+    @FutureOrPresent
+    private LocalDate dueDate;
+    private String periodType;
     @NotNull
     @Builder.Default
     private List<String> tags = new ArrayList<>();
-    private String details;
-    private LocalDateTime dueDateTime;
-    private LocalDate travelStartAt;
-    private LocalDate travelEndAt;
-    private String location;
-    private int minPerson;
-    private int maxPerson;
-    private int budget;
     @NotNull
     private Boolean completionStatus;
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -6,8 +6,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.member.entity.Users;
-import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.time.LocalDate;
@@ -19,53 +17,44 @@ import java.util.List;
 public class TravelDetailResponse {
 
     private int travelNumber;
-    private String title;
-    private String summary;
     private int userNumber;
     private String userName;
-    private List<String> tags;
-    private String details;
-    private int viewCount;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate travelStartAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate travelEndAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime registerDue;
     private String location;
-    private int minPerson;
+    private String title;
+    private String details;
+    //private int viewCount;
+    //private int nowPerson;
     private int maxPerson;
-    private int budget;
+    private String genderType;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate dueDate;
+    private String periodType;
+    private List<String> tags;
     private String postStatus;
-    //TODO: Image 처리, 현재 모집 확정된 인원수 처리
-
+    //TODO: 조회수, 현재 모집 확정된 인원수 처리
 
     @Builder
     public TravelDetailResponse(
-            int travelNumber, String title, String summary,
-            int userNumber, String userName, List<String> tags, String details, int viewCount,
-            LocalDateTime createdAt, LocalDate travelStartAt, LocalDate travelEndAt,
-            LocalDateTime registerDue, String location, int minPerson, int maxPerson,
-            int budget, String postStatus
+            int travelNumber, int userNumber, String userName,
+            LocalDateTime createdAt, String location, String title,
+            String details, int maxPerson, String genderType,
+            LocalDate dueDate, String periodType, List<String> tags,
+            String postStatus
     ) {
         this.travelNumber = travelNumber;
-        this.title = title;
-        this.summary = summary;
         this.userNumber = userNumber;
         this.userName = userName;
-        this.tags = tags;
-        this.details = details;
-        this.viewCount = viewCount;
         this.createdAt = createdAt;
-        this.travelStartAt = travelStartAt;
-        this.travelEndAt = travelEndAt;
-        this.registerDue = registerDue;
         this.location = location;
-        this.minPerson = minPerson;
+        this.title = title;
+        this.details = details;
         this.maxPerson = maxPerson;
-        this.budget = budget;
+        this.genderType = genderType;
+        this.dueDate = dueDate;
+        this.periodType = periodType;
+        this.tags = tags;
         this.postStatus = postStatus;
     }
 
@@ -75,22 +64,18 @@ public class TravelDetailResponse {
             List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
-        this.title = travel.getTitle();
-        this.summary = travel.getSummary();
         this.userNumber = userNumber;
         this.userName = userName;
-        this.tags = tags;
-        this.details = travel.getDetails();
-        this.viewCount = travel.getViewCount();
         this.createdAt = travel.getCreatedAt();
-        this.travelStartAt = travel.getStartAt();
-        this.travelEndAt = travel.getEndAt();
-        this.registerDue = travel.getDueDateTime();
         this.location = travel.getLocation();
-        this.minPerson = travel.getMinPerson();
+        this.title = travel.getTitle();
+        this.details = travel.getDetails();
         this.maxPerson = travel.getMaxPerson();
-        this.budget = travel.getBudget();
-        this.postStatus = travel.getStatus().getName();
+        this.genderType = travel.getGenderType().toString();
+        this.dueDate = travel.getDueDate();
+        this.periodType = travel.getPeriodType().toString();
+        this.tags = tags;
+        this.postStatus = travel.getStatus().toString();
     }
 
     public static TravelDetailResponse from(
@@ -100,22 +85,18 @@ public class TravelDetailResponse {
     ) {
         return TravelDetailResponse.builder()
                 .travelNumber(travel.getNumber())
-                .title(travel.getTitle())
-                .summary(travel.getSummary())
                 .userNumber(userNumber)
                 .userName(userName)
-                .tags(tags)
-                .details(travel.getDetails())
-                .viewCount(travel.getViewCount())
                 .createdAt(travel.getCreatedAt())
-                .travelStartAt(travel.getStartAt())
-                .travelEndAt(travel.getEndAt())
-                .registerDue(travel.getDueDateTime())
                 .location(travel.getLocation())
-                .minPerson(travel.getMinPerson())
+                .title(travel.getTitle())
+                .details(travel.getDetails())
                 .maxPerson(travel.getMaxPerson())
-                .budget(travel.getBudget())
-                .postStatus(travel.getStatus().getName())
+                .genderType(travel.getGenderType().toString())
+                .dueDate(travel.getDueDate())
+                .periodType(travel.getPeriodType().toString())
+                .tags(tags)
+                .postStatus(travel.getStatus().toString())
                 .build();
     }
 
@@ -123,21 +104,17 @@ public class TravelDetailResponse {
     public String toString() {
         return "TravelDetailResponse{" +
                 "travelNumber=" + travelNumber +
-                ", title='" + title + '\'' +
-                ", summary='" + summary + '\'' +
                 ", userNumber=" + userNumber +
                 ", userName='" + userName + '\'' +
-                ", tags=" + tags +
-                ", details='" + details + '\'' +
-                ", viewCount=" + viewCount +
                 ", createdAt=" + createdAt +
-                ", travelStartAt=" + travelStartAt +
-                ", travelEndAt=" + travelEndAt +
-                ", registerDue=" + registerDue +
                 ", location='" + location + '\'' +
-                ", minPerson=" + minPerson +
+                ", title='" + title + '\'' +
+                ", details='" + details + '\'' +
                 ", maxPerson=" + maxPerson +
-                ", budget=" + budget +
+                ", genderType='" + genderType + '\'' +
+                ", dueDate=" + dueDate +
+                ", periodType='" + periodType + '\'' +
+                ", tags=" + tags +
                 ", postStatus='" + postStatus + '\'' +
                 '}';
     }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.time.LocalDate;
@@ -32,15 +31,13 @@ public class TravelRecentDto {
     private LocalDateTime createdAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDate registerDue;
-    private String postStatus;
 
 
     @Builder
-    @QueryProjection
     public TravelRecentDto(
             int travelNumber, String title, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, String postStatus
+            LocalDateTime createdAt, LocalDate registerDue
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -51,27 +48,22 @@ public class TravelRecentDto {
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
         this.registerDue = registerDue;
-        this.postStatus = postStatus;
     }
 
-
-    public TravelRecentDto(Travel travel, List<Tag> tags) {
+    @QueryProjection
+    public TravelRecentDto(
+            Travel travel, int userNumber, String userName,
+            List<String> tags
+    ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
-        this.userNumber = travel.getUserNumber();
-        this.userName = "testuser"; //todo
-        this.tags = convertToTagNames(tags);
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.tags = tags.stream().limit(TAG_MAX_NUMBER).toList();
         this.nowPerson = 1; //todo
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();
-    }
-
-    private List<String> convertToTagNames(List<Tag> tags) {
-        return tags.stream()
-                .limit(TAG_MAX_NUMBER)
-                .map(tag -> tag.getName())
-                .toList();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.travel.domain.Travel;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,49 +23,48 @@ public class TravelRecentDto {
     @NotNull
     private int travelNumber;
     private String title;
-    private String summary;
     private int userNumber;
     private String userName;
+    private List<String> tags;
+    private int nowPerson;
+    private int maxPerson;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDateTime createdAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
-    private LocalDateTime registerDue;
-    private int maxPerson;
-    private int nowPerson;
-    private List<String> tags;
-    //TODO: 이미지
+    private LocalDate registerDue;
+    private String postStatus;
 
 
     @Builder
     @QueryProjection
     public TravelRecentDto(
-            int travelNumber, String title, String summary, int userNumber, String userName,
-            LocalDateTime createdAt, LocalDateTime registerDue, int maxPerson, int nowPerson,
-            List<String> tags) {
+            int travelNumber, String title, int userNumber, String userName,
+            List<String> tags, int nowPerson, int maxPerson,
+            LocalDateTime createdAt, LocalDate registerDue, String postStatus
+    ) {
         this.travelNumber = travelNumber;
         this.title = title;
-        this.summary = summary;
         this.userNumber = userNumber;
         this.userName = userName;
+        this.tags = tags;
+        this.nowPerson = nowPerson;
+        this.maxPerson = maxPerson;
         this.createdAt = createdAt;
         this.registerDue = registerDue;
-        this.maxPerson = maxPerson;
-        this.nowPerson = nowPerson;
-        this.tags = tags;
+        this.postStatus = postStatus;
     }
 
 
     public TravelRecentDto(Travel travel, List<Tag> tags) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
-        this.summary = travel.getSummary();
         this.userNumber = travel.getUserNumber();
         this.userName = "testuser"; //todo
-        this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDateTime();
-        this.maxPerson = travel.getMaxPerson();
-        this.nowPerson = 1; //todo
         this.tags = convertToTagNames(tags);
+        this.nowPerson = 1; //todo
+        this.maxPerson = travel.getMaxPerson();
+        this.createdAt = travel.getCreatedAt();
+        this.registerDue = travel.getDueDate();
     }
 
     private List<String> convertToTagNames(List<Tag> tags) {
@@ -74,19 +74,4 @@ public class TravelRecentDto {
                 .toList();
     }
 
-    @Override
-    public String toString() {
-        return "TravelRecentResponse{" +
-                "travelNumber=" + travelNumber +
-                ", title='" + title + '\'' +
-                ", summary='" + summary + '\'' +
-                ", userNumber=" + userNumber +
-                ", userName='" + userName + '\'' +
-                ", createdAt=" + createdAt +
-                ", registerDue=" + registerDue +
-                ", maxPerson=" + maxPerson +
-                ", nowPerson=" + nowPerson +
-                ", tags=" + tags +
-                '}';
-    }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -49,15 +49,15 @@ public class TravelSearchDto {
 
     @QueryProjection
     public TravelSearchDto(
-            Travel travel,
+            Travel travel, int userNumber, String userName,
             List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
-        this.userNumber = travel.getUserNumber();
-        this.userName = "testuser";
+        this.userNumber = userNumber;
+        this.userName = userName;
         this.tags = tags;
-        this.nowPerson = 1;
+        this.nowPerson = 1; //TODO
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -16,8 +16,6 @@ import java.util.List;
 @Getter
 public class TravelSearchDto {
 
-    private static final int TAG_MAX_NUMBER = 3;
-
     private int travelNumber;
     private String title;
     private int userNumber;
@@ -58,7 +56,7 @@ public class TravelSearchDto {
         this.title = travel.getTitle();
         this.userNumber = travel.getUserNumber();
         this.userName = "testuser";
-        this.tags = tags.stream().limit(TAG_MAX_NUMBER).toList();
+        this.tags = tags;
         this.nowPerson = 1;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,15 +28,14 @@ public class TravelSearchDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
     private LocalDateTime createdAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
-    private LocalDateTime registerDue;
+    private LocalDate registerDue;
     private String postStatus;
-    //TODO: 이미지
 
     @Builder
     public TravelSearchDto(
             int travelNumber, String title, int userNumber, String userName,
             List<String> tags, int maxPerson, int nowPerson,
-            LocalDateTime createdAt, LocalDateTime registerDue, String postStatus
+            LocalDateTime createdAt, LocalDate registerDue, String postStatus
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -62,7 +62,7 @@ public class TravelSearchDto {
         this.nowPerson = 1;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDateTime();
+        this.registerDue = travel.getDueDate();
         this.postStatus = travel.getStatus().getName();
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -77,6 +77,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
         List<TravelRecentDto> content = queryFactory
                 .select(travel)
                 .from(travel)
+                .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
@@ -85,7 +86,10 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .orderBy(travel.createdAt.desc())
                 .transform(groupBy(travel.number).list(
                         Projections.constructor(TravelRecentDto.class,
-                                travel, list(tag)))
+                                travel,
+                                users.userNumber,
+                                users.userName,
+                                list(tag.name)))
                 );
 
         JPAQuery<Long> countQuery = queryFactory
@@ -121,6 +125,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
         List<TravelSearchDto> content = queryFactory
                 .select(travel)
                 .from(travel)
+                .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
@@ -129,7 +134,10 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .orderBy(travel.createdAt.desc())
                 .transform(groupBy(travel.number).list(
                         Projections.constructor(TravelSearchDto.class,
-                                travel, list(tag.name)))
+                                travel,
+                                users.userNumber,
+                                users.userName,
+                                list(tag.name)))
                 );
 
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -67,7 +67,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number)
                 .from(travel)
                 .where(
-                        statusActivated()
+                        statusInProgress()
                 )
                 .orderBy(travel.createdAt.desc())
                 .offset(pageRequest.getOffset())
@@ -80,8 +80,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
-                        travel.number.in(travels),
-                        statusActivated()
+                        travel.number.in(travels)
                 )
                 .orderBy(travel.createdAt.desc())
                 .transform(groupBy(travel.number).list(
@@ -158,6 +157,10 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
     private BooleanExpression statusActivated() {
         return travel.status.eq(TravelStatus.IN_PROGRESS)
                 .or(travel.status.eq(TravelStatus.CLOSED));
+    }
+
+    private BooleanExpression statusInProgress() {
+        return travel.status.eq(TravelStatus.IN_PROGRESS);
     }
 
     private BooleanExpression eqTags(List<String> tags) {

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -18,6 +18,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
@@ -163,6 +165,8 @@ class TravelControllerTest {
         return travelRepository.save(Travel.builder()
                 .title("Travel Controller")
                 .userNumber(userNumber)
+                .genderType(GenderType.NONE)
+                .periodType(PeriodType.NONE)
                 .status(status)
                 .build()
         );

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -15,6 +15,8 @@ import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.domain.TravelTag;
 import swyp.swyp6_team7.tag.repository.TagRepository;
 import swyp.swyp6_team7.tag.repository.TravelTagRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
@@ -48,6 +50,8 @@ class TravelCustomRepositoryImplTest {
                 .title("기본 테스트 데이터")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build());
@@ -73,6 +77,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터1")
                 .userNumber(user.getUserNumber())
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build());
@@ -98,6 +104,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now().plusDays(1))
                 .status(TravelStatus.IN_PROGRESS)
                 .build();
@@ -145,6 +153,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build();
@@ -171,6 +181,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build();
@@ -197,6 +209,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터1")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.DELETED)
                 .build();
@@ -205,6 +219,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터2")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.DELETED)
                 .build();
@@ -232,6 +248,8 @@ class TravelCustomRepositoryImplTest {
                     .title("추가 테스트 데이터")
                     .userNumber(1)
                     .viewCount(0)
+                    .periodType(PeriodType.NONE)
+                    .genderType(GenderType.NONE)
                     .createdAt(LocalDateTime.now())
                     .status(TravelStatus.IN_PROGRESS)
                     .build());
@@ -261,6 +279,8 @@ class TravelCustomRepositoryImplTest {
                     .title("추가 테스트 데이터" + i)
                     .userNumber(1)
                     .viewCount(0)
+                    .periodType(PeriodType.NONE)
+                    .genderType(GenderType.NONE)
                     .createdAt(LocalDateTime.now())
                     .status(TravelStatus.IN_PROGRESS)
                     .build());
@@ -295,6 +315,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터1")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build());
@@ -306,6 +328,8 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터2")
                 .userNumber(1)
                 .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
                 .build());


### PR DESCRIPTION
## 🔗 Issue Number

feat: 여행 콘텐츠 데이터 및 CRUD 수정 #17 

## PR 유형
- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
- Travel 도메인 필드 변경
  - 기간, 성별의 경우 Enum으로 관리
  - 기획에서 제외된 필드 삭제
 - 변경된 도메인에 맞춰 DTO 및 테스트 코드 수정
 - 이외의 사소한 오류 수정
   - Response 과정에서 더미데이터로 고정해두었던 userName에 실제 사용자 이름이 들어가도록 수정
   - search 과정에서 Request param의 tags가 null일 때 발생하던 오류를 수정
   - 지금 참가 가능한 콘텐츠 조회에서 상태가 IN_PROGRESS인 경우만 가져오도록 수정


## 🔖 리뷰 요구사항(선택)

.


## ✅ PR Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
