### PR TITLE
feat: 여행콘텐츠 검색 성별, 인원, 기간 필터링 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -64,13 +64,21 @@ public class TravelController {
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "5") int size,
             @RequestParam(name = "keyword", required = false) String keyword,
+            @RequestParam(name = "location", required = false) List<String> selectedLocation,
+            @RequestParam(name = "gender", required = false) List<String> selectedGender,
+            @RequestParam(name = "person", required = false) List<String> selectedPerson,
+            @RequestParam(name = "period", required = false) List<String> selectedPeriod,
             @RequestParam(name = "tags", required = false) List<String> tags
     ) {
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(page, size))
                 .keyword(keyword)
-                .tags(tags == null ? new ArrayList<>() : tags)
+//                .locationType(locationTypes)
+                .genderTypes(selectedGender)
+//                .personType(personTypes)
+//                .periodType(periodTypes)
+                .tags(tags)
                 .build();
         log.info("search tags: " + condition.getTags());
 

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -76,11 +76,10 @@ public class TravelController {
                 .keyword(keyword)
 //                .locationType(locationTypes)
                 .genderTypes(selectedGender)
-//                .personType(personTypes)
+                .personTypes(selectedPerson)
                 .periodTypes(selectedPeriod)
                 .tags(tags)
                 .build();
-        log.info("search tags: " + condition.getTags());
 
         Page<TravelSearchDto> travels = travelService.search(condition);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -73,7 +73,7 @@ public class TravelController {
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(page, size))
                 .keyword(keyword)
-//                .locationType(locationTypes)
+                .locationTypes(selectedLocation)
                 .genderTypes(selectedGender)
                 .personTypes(selectedPerson)
                 .periodTypes(selectedPeriod)

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -16,7 +16,6 @@ import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.service.TravelService;
 
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -67,7 +67,7 @@ public class TravelController {
             @RequestParam(name = "gender", required = false) List<String> selectedGender,
             @RequestParam(name = "person", required = false) List<String> selectedPerson,
             @RequestParam(name = "period", required = false) List<String> selectedPeriod,
-            @RequestParam(name = "tags", required = false) List<String> tags
+            @RequestParam(name = "tags", required = false) List<String> selectedTags
     ) {
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -77,7 +77,7 @@ public class TravelController {
                 .genderTypes(selectedGender)
                 .personTypes(selectedPerson)
                 .periodTypes(selectedPeriod)
-                .tags(tags)
+                .tags(selectedTags)
                 .build();
 
         Page<TravelSearchDto> travels = travelService.search(condition);

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -77,7 +77,7 @@ public class TravelController {
 //                .locationType(locationTypes)
                 .genderTypes(selectedGender)
 //                .personType(personTypes)
-//                .periodType(periodTypes)
+                .periodTypes(selectedPeriod)
                 .tags(tags)
                 .build();
         log.info("search tags: " + condition.getTags());

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -42,7 +42,7 @@ public class TravelSearchCondition {
         this.genderFilter = getGenderFilter(genderTypes);
         this.personRangeFilter = getPersonFilter(personTypes);
         this.periodFilter = getPeriodFilter(periodTypes);
-        this.tags = tags == null ? new ArrayList<>() : tags;
+        this.tags = getTags(tags);
     }
 
     private List<GenderType> getGenderFilter(List<String> genderTypes) {
@@ -71,6 +71,15 @@ public class TravelSearchCondition {
         return periodTypes.stream()
                 .distinct().limit(TravelSearchConstant.PERIOD_TYPE_COUNT)
                 .map(PeriodType::of)
+                .toList();
+    }
+
+    private List<String> getTags(List<String> tags) {
+        if (tags == null) {
+            return new ArrayList<>();
+        }
+        return tags.stream()
+                .distinct()
                 .toList();
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,7 @@ public class TravelSearchCondition {
     //private String locationFilter;
     private List<GenderType> genderFilter;
     //private List<String> personRangeFilter;
-    //private List<PeriodType> periodFilter;
+    private List<PeriodType> periodFilter;
     private List<String> tags;
 
     //정렬 -> 추천순, 최신순, 등록일순, 정확도순
@@ -31,7 +32,7 @@ public class TravelSearchCondition {
 //            List<String> locationTypes,
             List<String> genderTypes,
 //            List<String> personTypes,
-//            List<String> periodTypes,
+            List<String> periodTypes,
             List<String> tags
     ) {
         this.pageRequest = pageRequest;
@@ -39,7 +40,7 @@ public class TravelSearchCondition {
         //location
         this.genderFilter = getGenderFilter(genderTypes);
         //person
-        //period
+        this.periodFilter = getPeriodFilter(periodTypes);
         this.tags = tags == null ? new ArrayList<>() : tags;
     }
 
@@ -48,6 +49,13 @@ public class TravelSearchCondition {
             return new ArrayList<>();
         }
         return genderTypes.stream().distinct().map(GenderType::of).toList();
+    }
+
+    private List<PeriodType> getPeriodFilter(List<String> periodTypes) {
+        if (periodTypes == null) {
+            return new ArrayList<>();
+        }
+        return periodTypes.stream().distinct().map(PeriodType::of).toList();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import swyp.swyp6_team7.travel.domain.GenderType;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,20 +16,38 @@ public class TravelSearchCondition {
 
     private PageRequest pageRequest;
     private String keyword;
+    //private String locationFilter;
+    private List<GenderType> genderFilter;
+    //private List<String> personRangeFilter;
+    //private List<PeriodType> periodFilter;
     private List<String> tags;
 
-    //장소 -> 국내, 해외
-    //인원 -> maxPerson
-    //성별 -> GenderType
-    //기간 -> PeriodType
     //정렬 -> 추천순, 최신순, 등록일순, 정확도순
 
-
     @Builder
-    public TravelSearchCondition(PageRequest pageRequest, String keyword, List<String> tags) {
+    public TravelSearchCondition(
+            PageRequest pageRequest,
+            String keyword,
+//            List<String> locationTypes,
+            List<String> genderTypes,
+//            List<String> personTypes,
+//            List<String> periodTypes,
+            List<String> tags
+    ) {
         this.pageRequest = pageRequest;
         this.keyword = keyword;
-        this.tags = tags;
+        //location
+        this.genderFilter = getGenderFilter(genderTypes);
+        //person
+        //period
+        this.tags = tags == null ? new ArrayList<>() : tags;
+    }
+
+    private List<GenderType> getGenderFilter(List<String> genderTypes) {
+        if (genderTypes == null) {
+            return new ArrayList<>();
+        }
+        return genderTypes.stream().distinct().map(GenderType::of).toList();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -18,7 +18,7 @@ public class TravelSearchCondition {
 
     private PageRequest pageRequest;
     private String keyword;
-    //private String locationFilter;
+    private List<String> locationFilter;
     private List<GenderType> genderFilter;
     private List<String> personRangeFilter;
     private List<PeriodType> periodFilter;
@@ -30,7 +30,7 @@ public class TravelSearchCondition {
     public TravelSearchCondition(
             PageRequest pageRequest,
             String keyword,
-//            List<String> locationTypes,
+            List<String> locationTypes,
             List<String> genderTypes,
             List<String> personTypes,
             List<String> periodTypes,
@@ -38,11 +38,20 @@ public class TravelSearchCondition {
     ) {
         this.pageRequest = pageRequest;
         this.keyword = keyword;
-        //location
+        this.locationFilter = getLocationFilter(locationTypes);
         this.genderFilter = getGenderFilter(genderTypes);
         this.personRangeFilter = getPersonFilter(personTypes);
         this.periodFilter = getPeriodFilter(periodTypes);
         this.tags = getTags(tags);
+    }
+
+    private List<String> getLocationFilter(List<String> locationTypes) {
+        if (locationTypes == null) {
+            return new ArrayList<>();
+        }
+        return locationTypes.stream()
+                .distinct().limit(TravelSearchConstant.LOCATION_TYPE_COUNT)
+                .toList();
     }
 
     private List<GenderType> getGenderFilter(List<String> genderTypes) {

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.util.TravelSearchConstant;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class TravelSearchCondition {
         this.keyword = keyword;
         //location
         this.genderFilter = getGenderFilter(genderTypes);
-        this.personRangeFilter = personTypes;
+        this.personRangeFilter = getPersonFilter(personTypes);
         this.periodFilter = getPeriodFilter(periodTypes);
         this.tags = tags == null ? new ArrayList<>() : tags;
     }
@@ -48,14 +49,29 @@ public class TravelSearchCondition {
         if (genderTypes == null) {
             return new ArrayList<>();
         }
-        return genderTypes.stream().distinct().map(GenderType::of).toList();
+        return genderTypes.stream()
+                .distinct().limit(TravelSearchConstant.GENDER_TYPE_COUNT)
+                .map(GenderType::of)
+                .toList();
+    }
+
+    private List<String> getPersonFilter(List<String> personTypes) {
+        if (personTypes == null) {
+            return new ArrayList<>();
+        }
+        return personTypes.stream()
+                .distinct().limit(TravelSearchConstant.PERSON_TYPE_COUNT)
+                .toList();
     }
 
     private List<PeriodType> getPeriodFilter(List<String> periodTypes) {
         if (periodTypes == null) {
             return new ArrayList<>();
         }
-        return periodTypes.stream().distinct().map(PeriodType::of).toList();
+        return periodTypes.stream()
+                .distinct().limit(TravelSearchConstant.PERIOD_TYPE_COUNT)
+                .map(PeriodType::of)
+                .toList();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -19,7 +19,7 @@ public class TravelSearchCondition {
     private String keyword;
     //private String locationFilter;
     private List<GenderType> genderFilter;
-    //private List<String> personRangeFilter;
+    private List<String> personRangeFilter;
     private List<PeriodType> periodFilter;
     private List<String> tags;
 
@@ -31,7 +31,7 @@ public class TravelSearchCondition {
             String keyword,
 //            List<String> locationTypes,
             List<String> genderTypes,
-//            List<String> personTypes,
+            List<String> personTypes,
             List<String> periodTypes,
             List<String> tags
     ) {
@@ -39,7 +39,7 @@ public class TravelSearchCondition {
         this.keyword = keyword;
         //location
         this.genderFilter = getGenderFilter(genderTypes);
-        //person
+        this.personRangeFilter = personTypes;
         this.periodFilter = getPeriodFilter(periodTypes);
         this.tags = tags == null ? new ArrayList<>() : tags;
     }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -198,21 +198,21 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
         }
 
         if (personTypes.size() == 1) {
-            if (personTypes.get(0).equals(TravelSearchConstant.PERSON_TYPE_SMALL)) {
-                return travel.maxPerson.loe(2);
-            } else if (personTypes.get(0).equals(TravelSearchConstant.PERSON_TYPE_MIDDLE)) {
-                return travel.maxPerson.between(3, 4);
-            } else {
-                return travel.maxPerson.goe(5);
-            }
+            return getPersonRangeBooleanExpression(personTypes.get(0));
         } else {
-            if (personTypes.containsAll(new ArrayList<>(List.of(TravelSearchConstant.PERSON_TYPE_SMALL, TravelSearchConstant.PERSON_TYPE_MIDDLE)))) {
-                return travel.maxPerson.loe(2).or(travel.maxPerson.between(3, 4));
-            } else if (personTypes.containsAll(new ArrayList<>(List.of(TravelSearchConstant.PERSON_TYPE_SMALL, TravelSearchConstant.PERSON_TYPE_LARGE)))) {
-                return travel.maxPerson.loe(2).or(travel.maxPerson.goe(5));
-            } else {
-                return travel.maxPerson.between(3, 4).or(travel.maxPerson.goe(5));
-            }
+            return getPersonRangeBooleanExpression(personTypes.get(0)).or(getPersonRangeBooleanExpression(personTypes.get(1)));
+        }
+    }
+
+    private BooleanExpression getPersonRangeBooleanExpression(String personType) {
+        if (personType.equals(TravelSearchConstant.PERSON_TYPE_SMALL)) {
+            return travel.maxPerson.loe(2);
+        } else if (personType.equals(TravelSearchConstant.PERSON_TYPE_MIDDLE)) {
+            return travel.maxPerson.between(3, 4);
+        } else if (personType.equals(TravelSearchConstant.PERSON_TYPE_LARGE)) {
+            return travel.maxPerson.goe(5);
+        } else {
+            throw new IllegalArgumentException("잘못된 person filtering 조건입니다.");
         }
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -118,6 +118,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         titleLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
+                        eqPersonRangeType(condition.getPersonRangeFilter()),
                         eqPeriodType(condition.getPeriodFilter()),
                         eqTags(condition.getTags())
                 )
@@ -156,6 +157,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         titleLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
+                        eqPersonRangeType(condition.getPersonRangeFilter()),
                         eqPeriodType(condition.getPeriodFilter()),
                         eqTags(condition.getTags())
                 );
@@ -188,6 +190,30 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
             return null;
         }
         return travel.genderType.in(genderCondition);
+    }
+
+    public BooleanExpression eqPersonRangeType(List<String> personTypes) {
+        if (personTypes.isEmpty() || personTypes.size() == TravelSearchConstant.PERSON_TYPE_COUNT) {
+            return null;
+        }
+
+        if (personTypes.size() == 1) {
+            if (personTypes.get(0).equals(TravelSearchConstant.PERSON_TYPE_SMALL)) {
+                return travel.maxPerson.loe(2);
+            } else if (personTypes.get(0).equals(TravelSearchConstant.PERSON_TYPE_MIDDLE)) {
+                return travel.maxPerson.between(3, 4);
+            } else {
+                return travel.maxPerson.goe(5);
+            }
+        } else {
+            if (personTypes.containsAll(new ArrayList<>(List.of(TravelSearchConstant.PERSON_TYPE_SMALL, TravelSearchConstant.PERSON_TYPE_MIDDLE)))) {
+                return travel.maxPerson.loe(2).or(travel.maxPerson.between(3, 4));
+            } else if (personTypes.containsAll(new ArrayList<>(List.of(TravelSearchConstant.PERSON_TYPE_SMALL, TravelSearchConstant.PERSON_TYPE_LARGE)))) {
+                return travel.maxPerson.loe(2).or(travel.maxPerson.goe(5));
+            } else {
+                return travel.maxPerson.between(3, 4).or(travel.maxPerson.goe(5));
+            }
+        }
     }
 
     private BooleanExpression eqPeriodType(List<PeriodType> periodCondition) {

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -114,7 +114,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
-                        titleLike(condition.getKeyword()),
+                        titleAndLocationLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
                         eqPersonRangeType(condition.getPersonRangeFilter()),
@@ -153,7 +153,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
-                        titleLike(condition.getKeyword()),
+                        titleAndLocationLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
                         eqPersonRangeType(condition.getPersonRangeFilter()),
@@ -168,11 +168,11 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
     /**
      * Where절 BooleanExpression
      */
-    private BooleanExpression titleLike(String keyword) {
+    private BooleanExpression titleAndLocationLike(String keyword) {
         if (StringUtils.isNullOrEmpty(keyword)) {
             return null;
         }
-        return travel.title.contains(keyword);
+        return travel.title.contains(keyword).or(travel.location.like(keyword));
     }
 
     private BooleanExpression statusActivated() {

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -118,6 +118,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         titleLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
+                        eqPeriodType(condition.getPeriodFilter()),
                         eqTags(condition.getTags())
                 )
                 .groupBy(travel.number)
@@ -155,6 +156,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         titleLike(condition.getKeyword()),
                         statusActivated(),
                         eqGenderTypes(condition.getGenderFilter()),
+                        eqPeriodType(condition.getPeriodFilter()),
                         eqTags(condition.getTags())
                 );
 
@@ -186,6 +188,13 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
             return null;
         }
         return travel.genderType.in(genderCondition);
+    }
+
+    private BooleanExpression eqPeriodType(List<PeriodType> periodCondition) {
+        if (periodCondition.isEmpty() || periodCondition.size() == TravelSearchConstant.PERIOD_TYPE_COUNT) {
+            return null;
+        }
+        return travel.periodType.in(periodCondition);
     }
 
     private BooleanExpression eqTags(List<String> tags) {

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Repository;
 import swyp.swyp6_team7.member.entity.QUsers;
 import swyp.swyp6_team7.tag.domain.QTag;
 import swyp.swyp6_team7.tag.domain.QTravelTag;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.QTravel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
@@ -20,7 +22,9 @@ import swyp.swyp6_team7.travel.dto.response.QTravelDetailResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+import swyp.swyp6_team7.travel.util.TravelSearchConstant;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
@@ -113,6 +117,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .where(
                         titleLike(condition.getKeyword()),
                         statusActivated(),
+                        eqGenderTypes(condition.getGenderFilter()),
                         eqTags(condition.getTags())
                 )
                 .groupBy(travel.number)
@@ -149,12 +154,17 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .where(
                         titleLike(condition.getKeyword()),
                         statusActivated(),
+                        eqGenderTypes(condition.getGenderFilter()),
                         eqTags(condition.getTags())
                 );
 
         return PageableExecutionUtils.getPage(content, condition.getPageRequest(), countQuery::fetchOne);
     }
 
+
+    /**
+     * Where절 BooleanExpression
+     */
     private BooleanExpression titleLike(String keyword) {
         if (StringUtils.isNullOrEmpty(keyword)) {
             return null;
@@ -169,6 +179,13 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
     private BooleanExpression statusInProgress() {
         return travel.status.eq(TravelStatus.IN_PROGRESS);
+    }
+
+    private BooleanExpression eqGenderTypes(List<GenderType> genderCondition) {
+        if (genderCondition.isEmpty() || genderCondition.size() == TravelSearchConstant.GENDER_TYPE_COUNT) {
+            return null;
+        }
+        return travel.genderType.in(genderCondition);
     }
 
     private BooleanExpression eqTags(List<String> tags) {

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -24,7 +24,6 @@ import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.util.TravelSearchConstant;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.querydsl.core.group.GroupBy.groupBy;

--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelSearchConstant.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelSearchConstant.java
@@ -1,0 +1,20 @@
+package swyp.swyp6_team7.travel.util;
+
+public class TravelSearchConstant {
+
+    //국내, 해외
+    public final static int LOCATION_TYPE_COUNT = 2;
+
+    //모두, 여자만, 남자만
+    public final static int GENDER_TYPE_COUNT = 3;
+
+    //2명, 3~4명, 5명 이상
+    public final static int PERSON_TYPE_COUNT = 3;
+    public final static String PERSON_TYPE_SMALL = "2명";
+    public final static String PERSON_TYPE_MIDDLE = "3~4명";
+    public final static String PERSON_TYPE_LARGE = "5명 이상";
+
+    //일주일 이하, 1~2주, 3~4주, 한 달 이상
+    public final static int PERIOD_TYPE_COUNT = 4;
+
+}

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -355,4 +355,50 @@ class TravelCustomRepositoryImplTest {
         assertThat(result.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터2");
     }
 
+    @DisplayName("search: 주어지는 젠더 타입에 알맞은 콘텐츠를 가져올 수 있다")
+    @Test
+    public void searchWithGenderFilter() {
+        // given
+        Travel travel1 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터1")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.WOMAN_ONLY)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel2 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터2")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.MIXED)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel3 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터3")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.MAN_ONLY)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .genderTypes(new ArrayList<>(List.of(GenderType.WOMAN_ONLY.toString(), GenderType.MIXED.toString())))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
+    }
+
+
 }

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -448,5 +448,55 @@ class TravelCustomRepositoryImplTest {
         assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
     }
 
+    @DisplayName("search: 주어지는 인원 타입에 알맞은 콘텐츠를 가져올 수 있다")
+    @Test
+    public void searchWithPersonRangeFilter() {
+        // given
+        travelRepository.deleteAll();
+        Travel travel1 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터1")
+                .userNumber(1)
+                .viewCount(0)
+                .maxPerson(1)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel2 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터2")
+                .userNumber(1)
+                .viewCount(0)
+                .maxPerson(4)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel3 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터3")
+                .userNumber(1)
+                .viewCount(0)
+                .maxPerson(6)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .personTypes(List.of("2명", "5명 이상"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).doesNotContain(travel2.getNumber());
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel3.getNumber());
+    }
+
 
 }

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -400,5 +400,53 @@ class TravelCustomRepositoryImplTest {
         assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
     }
 
+    @DisplayName("search: 주어지는 기간 타입에 알맞은 콘텐츠를 가져올 수 있다")
+    @Test
+    public void searchWithPeriodFilter() {
+        // given
+        Travel travel1 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터1")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.MORE_THAN_MONTH)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel2 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터2")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.THREE_WEEKS)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel3 = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터3")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.TWO_WEEKS)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .periodTypes(new ArrayList<>(List.of(
+                        PeriodType.MORE_THAN_MONTH.toString(),
+                        PeriodType.THREE_WEEKS.toString()))
+                )
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
+        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
+    }
+
 
 }

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -173,6 +173,43 @@ class TravelCustomRepositoryImplTest {
         assertThat(results.getContent().size()).isEqualTo(1);
     }
 
+    @DisplayName("search: 제목과 장소에 keyword가 포함된 데이터를 찾을 수 있다")
+    @Test
+    public void searchWithKeywordThroughTitleAndLocation() {
+        // given
+        Travel travel = travelRepository.save(Travel.builder()
+                .title("추가 테스트 데이터")
+                .userNumber(1)
+                .viewCount(0)
+                .location("영국")
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+        Travel travel2 = travelRepository.save(Travel.builder()
+                .title("영국 테스트 데이터")
+                .userNumber(1)
+                .viewCount(0)
+                .periodType(PeriodType.NONE)
+                .genderType(GenderType.NONE)
+                .createdAt(LocalDateTime.now())
+                .status(TravelStatus.IN_PROGRESS)
+                .build());
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .keyword("영국")
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition);
+
+        // then
+        assertThat(results.getTotalElements()).isEqualTo(2);
+        assertThat(results.getContent().size()).isEqualTo(2);
+    }
+
     @DisplayName("search: 키워드가 주어지지 않을 경우 가능한 모든 콘텐츠를 전달")
     @Test
     public void searchWithoutKeyword() {


### PR DESCRIPTION
## 🔗 Issue Number
feat: 여행 콘텐츠 검색 필터링 - 성별, 인원, 기간 #20

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행콘텐츠 검색 중 성별, 인원, 기간 필터링 기능을 추가함
- TravelSearchConstant: 콘텐츠 검색에 필요한 상수들을 관리하기 위해 클래스 추가함
- TravelSearchConditon: 각 조건 리스트가 null인 경우 빈 리스트로 설정되도록 수정 및 적절히 가공
- TravelController: 변경된 TravelSearchCondition 생성 로직에 맞춰 수정
- TravelCustomRepositoryImpl: 각 조건 필터링을 위해 BooleanExpression 생성 메서드를 추가, 테스트코드 작성


## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
