### PR TITLE
feat: 추천 여행 콘텐츠 목록

### DIFF
--- a/src/main/java/swyp/swyp6_team7/auth/controller/LoginController.java
+++ b/src/main/java/swyp/swyp6_team7/auth/controller/LoginController.java
@@ -2,25 +2,39 @@ package swyp.swyp6_team7.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import swyp.swyp6_team7.auth.dto.LoginRequestDto;
 import swyp.swyp6_team7.auth.service.LoginService;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.service.MemberService;
+import swyp.swyp6_team7.member.service.UserLoginHistoryService;
 
 @RestController
 //@RequestMapping("/api")
 public class LoginController {
     private final LoginService loginService;
+    private final UserLoginHistoryService userLoginHistoryService;
+    private final MemberService memberService;
 
-    public LoginController(LoginService loginService) {
+    public LoginController(LoginService loginService, UserLoginHistoryService userLoginHistoryService, MemberService memberService) {
         this.loginService = loginService;
+        this.userLoginHistoryService = userLoginHistoryService;
+        this.memberService = memberService;
     }
+
 
     @PostMapping("/api/login")
     public ResponseEntity<String> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         try {
-            String accessToken = loginService.login(loginRequestDto, response); // response 추가
+            // LoginService에서 실제로 로그인 유저를 가져오도록 수정
+            String accessToken = loginService.login(loginRequestDto, response);
+            Users user = loginService.getUserByEmail(loginRequestDto.getEmail()); // 로그인한 유저 정보 가져오기
+            userLoginHistoryService.saveLoginHistory(user);  // 로그인 이력 저장
+            memberService.updateLoginDate(user);  // 로그인 시간 업데이트
             return ResponseEntity.ok("Bearer " + accessToken); // Access Token 반환
         } catch (UsernameNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());  // 404 Not Found 반환
@@ -28,4 +42,6 @@ public class LoginController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());  // 400 Bad Request 반환
         }
     }
+
+
 }

--- a/src/main/java/swyp/swyp6_team7/auth/controller/LogoutController.java
+++ b/src/main/java/swyp/swyp6_team7/auth/controller/LogoutController.java
@@ -1,0 +1,56 @@
+package swyp.swyp6_team7.auth.controller;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.auth.service.CustomUserDetails;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.service.MemberService;
+import swyp.swyp6_team7.member.service.UserLoginHistoryService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RestController
+public class LogoutController {
+    private static final Logger logger = LoggerFactory.getLogger(LogoutController.class);
+
+    private final UserLoginHistoryService userLoginHistoryService;
+    private final MemberService memberService;
+
+    public LogoutController(UserLoginHistoryService userLoginHistoryService, MemberService memberService) {
+        this.userLoginHistoryService = userLoginHistoryService;
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/api/logout")
+    public ResponseEntity<String> logout() {
+        // 현재 인증된 유저 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            logger.info("Authentication principal: {}", authentication.getPrincipal());
+            if (authentication.getPrincipal() instanceof CustomUserDetails) {
+                CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+                logger.info("Authenticated user's email: {}", customUserDetails.getUsername());
+
+                // 이메일로 Users 엔티티를 찾음
+                Users user = memberService.getUserByEmail(customUserDetails.getUsername());
+
+                // 로그아웃 이력 업데이트
+                userLoginHistoryService.updateLogoutHistory(user);
+                memberService.updateLogoutDate(user);
+
+                // SecurityContext에서 인증 정보 제거
+                SecurityContextHolder.clearContext();
+
+                return ResponseEntity.ok("Logout successful");
+            }
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("No user is logged in");
+
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/auth/controller/RefreshController.java
+++ b/src/main/java/swyp/swyp6_team7/auth/controller/RefreshController.java
@@ -9,6 +9,10 @@ import org.springframework.web.bind.annotation.RestController;
 import swyp.swyp6_team7.auth.jwt.JwtProvider;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api")
@@ -36,8 +40,13 @@ public class RefreshController {
                         Users user = userRepository.findByUserEmail(userEmail)
                                 .orElseThrow(() -> new IllegalArgumentException("이메일을 찾을 수 없습니다."));
 
+                        // GrantedAuthority에서 역할 리스트 추출
+                        List<String> roles = user.getAuthorities().stream()
+                                .map(GrantedAuthority::getAuthority)  // 권한을 String으로 변환
+                                .collect(Collectors.toList());
+
                         // 새로운 Access Token 발급
-                        String newAccessToken = jwtProvider.createAccessToken(user.getUserEmail(), user.getRoles());
+                        String newAccessToken = jwtProvider.createAccessToken(user.getUserEmail(), roles);
                         return ResponseEntity.ok("Bearer " + newAccessToken);
                     }
                 }

--- a/src/main/java/swyp/swyp6_team7/auth/jwt/JwtFilter.java
+++ b/src/main/java/swyp/swyp6_team7/auth/jwt/JwtFilter.java
@@ -11,17 +11,24 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import swyp.swyp6_team7.auth.service.CustomUserDetails;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.service.UserLoginHistoryService;
 
 import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @Component
 public class JwtFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final UserDetailsService userDetailsService;
+    private final UserLoginHistoryService userLoginHistoryService;
 
-    public JwtFilter(JwtProvider jwtProvider, UserDetailsService userDetailsService) {
+    public JwtFilter(JwtProvider jwtProvider, UserDetailsService userDetailsService, UserLoginHistoryService userLoginHistoryService) {
         this.jwtProvider = jwtProvider;
         this.userDetailsService = userDetailsService;
+        this.userLoginHistoryService = userLoginHistoryService;
     }
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -59,6 +66,16 @@ public class JwtFilter extends OncePerRequestFilter {
 
                     // SecurityContext에 인증 정보 설정
                     SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                    // SecurityContext에서 인증된 정보 가져오기
+                    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+                    if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+                        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+                        Users user = customUserDetails.getUser();
+                        userLoginHistoryService.saveLoginHistory(user);  // 로그인 이력 저장
+                    }
+
                 } catch (UsernameNotFoundException e) {
                     // 인증 실패 시 처리
                     // 로그를 남기거나 예외를 처리

--- a/src/main/java/swyp/swyp6_team7/auth/jwt/JwtProvider.java
+++ b/src/main/java/swyp/swyp6_team7/auth/jwt/JwtProvider.java
@@ -15,7 +15,7 @@ public class JwtProvider {
     private final long refreshTokenValidity = 7 * 24 * 60 * 60 * 1000; // 1주일
 
     // Access Token 생성
-    public String createAccessToken(String userEmail, List<String> roles) {
+    public String createAccessToken(String userEmail,  List<String> roles) {
         return createToken(userEmail, roles, accessTokenValidity);
     }
 
@@ -27,7 +27,7 @@ public class JwtProvider {
     // 공통적으로 토큰 생성하는 로직
     public String createToken(String userEmail, List<String> roles, long validityInMilliseconds) {
         Claims claims = Jwts.claims().setSubject(userEmail);
-        if (roles != null) {
+        if (roles != null &&!roles.isEmpty()) {
             claims.put("roles", roles);
         }
 

--- a/src/main/java/swyp/swyp6_team7/auth/service/CustomUserDetails.java
+++ b/src/main/java/swyp/swyp6_team7/auth/service/CustomUserDetails.java
@@ -1,0 +1,54 @@
+package swyp.swyp6_team7.auth.service;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import swyp.swyp6_team7.member.entity.Users;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+    private final Users user;
+
+    public CustomUserDetails(Users user) {
+        this.user = user;
+    }
+
+    public Users getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return user.getAuthorities();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getUserPw();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/swyp/swyp6_team7/auth/service/CustomUserDetailsService.java
@@ -21,6 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         Users user = userRepository.findByUserEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
-        return new org.springframework.security.core.userdetails.User(user.getUserEmail(), user.getUserPw(), user.getAuthorities());
+        // CustomUserDetails를 반환하도록 수정
+        return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/swyp/swyp6_team7/auth/service/LoginService.java
+++ b/src/main/java/swyp/swyp6_team7/auth/service/LoginService.java
@@ -12,6 +12,8 @@ import swyp.swyp6_team7.auth.jwt.JwtProvider;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
 
+import java.util.List;
+
 @Service
 public class LoginService {
     private final UserRepository userRepository;
@@ -37,7 +39,7 @@ public class LoginService {
         }
 
         // Access Token 생성
-        String accessToken = jwtProvider.createAccessToken(user.getUserEmail(), user.getRoles());
+        String accessToken = jwtProvider.createAccessToken(user.getUserEmail(), List.of(user.getRole().name()));
 
         // Refresh Token 생성 및 httpOnly 쿠키로 설정
         String refreshToken = jwtProvider.createRefreshToken(user.getUserEmail());
@@ -49,5 +51,10 @@ public class LoginService {
 
         // Access Token을 반환
         return accessToken;
+    }
+    // 이메일로 유저를 조회하는 메서드 추가
+    public Users getUserByEmail(String email) {
+        return userRepository.findByUserEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
     }
 }

--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package swyp.swyp6_team7.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -28,19 +29,35 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함
                 .authorizeHttpRequests(auth -> auth
+
+
+                        .requestMatchers(HttpMethod.GET, "/api/notices/**").permitAll() // 모든 사용자 조회 가능
+                        .requestMatchers(HttpMethod.POST, "/api/notices").hasRole("ADMIN") // POST는 관리자만 가능
+                        .requestMatchers(HttpMethod.PUT, "/api/notices/**").hasRole("ADMIN") // PUT은 관리자만 가능
+                        .requestMatchers(HttpMethod.DELETE, "/api/notices/**").hasRole("ADMIN") // DELETE는 관리자만 가능
+
+                        // 마이페이지 관련 권한 설정
+                        .requestMatchers("/api/profile/**").authenticated() // 마이페이지는 로그인한 사용자만 접근 가능
+
+                        // 기타 경로
                         .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**"
-                        ).permitAll()
-                        // 로그인, 회원가입, 토큰 재발급, kakao 로그인 요청 경로 경로는 허용
-                        .requestMatchers(
+                                "/api/admins/new",
                                 "/api/login",
+                                "/api/logout",
                                 "/api/users/new",
                                 "/api/refresh-token",
                                 "/login/oauth/kakao/**",
                                 "/error",
                                 "/api/users-email"
                         ).permitAll()
+
+
+
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가

--- a/src/main/java/swyp/swyp6_team7/member/controller/MemberController.java
+++ b/src/main/java/swyp/swyp6_team7/member/controller/MemberController.java
@@ -2,10 +2,13 @@ package swyp.swyp6_team7.member.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import swyp.swyp6_team7.member.dto.UserRequestDto;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.service.MemberService;
 import org.springframework.web.bind.annotation.*;
+import swyp.swyp6_team7.member.service.UserLoginHistoryService;
 
 import java.util.Map;
 
@@ -13,9 +16,11 @@ import java.util.Map;
 @RequestMapping("/api")
 public class MemberController {
     private final MemberService memberService;
+    private final UserLoginHistoryService userLoginHistoryService;
 
-    public MemberController(MemberService memberService) {
+    public MemberController(MemberService memberService,UserLoginHistoryService userLoginHistoryService) {
         this.memberService = memberService;
+        this.userLoginHistoryService = userLoginHistoryService;
     }
 
     @PostMapping("/users/new")
@@ -38,4 +43,11 @@ public class MemberController {
             return ResponseEntity.badRequest().body(e.getMessage());  // 이미 사용 중인 이메일
         }
     }
+    // 관리자 회원 가입
+    @PostMapping("/admins/new")
+    public ResponseEntity<?> createAdmin(@RequestBody UserRequestDto userRequestDto){
+        memberService.createAdmin(userRequestDto);
+        return new ResponseEntity<>("Admin successfully registered", HttpStatus.CREATED);
+    }
+
 }

--- a/src/main/java/swyp/swyp6_team7/member/dto/UserRequestDto.java
+++ b/src/main/java/swyp/swyp6_team7/member/dto/UserRequestDto.java
@@ -1,72 +1,36 @@
 package swyp.swyp6_team7.member.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+
+@Getter
+@Setter
 public class UserRequestDto {
     private String email;       // user_email
     private String password;    // user_pw
     private String name;   // user_name
     private String gender;      // user_gender (M/F)
-    private String birthYear;   // user_birth_year (yyyy)
-    private String phone;       // user_phone (전화번호)
+    private String agegroup;   // user_age_group
+    private List<String> preferredTags; // 사용자 선호 태그 리스트
+
+    // 관리자로 가입할 떄 사용하는 키
+    @Value("${custom.admin-secret-key}")
+    private String adminSecretKey;
 
     // 기본 생성자
     public UserRequestDto() {
     }
 
-    public UserRequestDto(String email, String password, String name, String gender, String birthYear, String phone) {
+    public UserRequestDto(String email, String password, String name, String gender, String agegroup, List<String> preferredTags) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.gender = gender;
-        this.birthYear = birthYear;
-        this.phone = phone;
+        this.agegroup = agegroup;
+        this.preferredTags = preferredTags;
     }
 
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-
-    public String getGender() {
-        return gender;
-    }
-
-    public void setGender(String gender) {
-        this.gender = gender;
-    }
-
-    public String getBirthYear() {
-        return birthYear;
-    }
-
-    public void setBirthYear(String birthYear) {
-        this.birthYear = birthYear;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
 }

--- a/src/main/java/swyp/swyp6_team7/member/entity/UserLoginHistory.java
+++ b/src/main/java/swyp/swyp6_team7/member/entity/UserLoginHistory.java
@@ -1,0 +1,27 @@
+package swyp.swyp6_team7.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "user_loginhistories")
+public class UserLoginHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int hisNumber;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_number", nullable = false)
+    private Users user;  // Users 테이블과의 관계 설정
+
+    @Column(name = "his_login_date", nullable = false)
+    private LocalDateTime hisLoginDate;
+
+    @Column(name = "his_logout_date")
+    private LocalDateTime hisLogoutDate;
+}

--- a/src/main/java/swyp/swyp6_team7/member/entity/UserProfile.java
+++ b/src/main/java/swyp/swyp6_team7/member/entity/UserProfile.java
@@ -1,0 +1,51 @@
+package swyp.swyp6_team7.member.entity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "user_profiles")
+public class UserProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer proNumber;
+
+    @Column(nullable = false)
+    private Integer userNumber;
+
+    @Column(length = 200)
+    private String proIntroduce;
+
+    private String profileImageUrl;  // 프로필 이미지 URL
+
+    // Getters and Setters
+    public Integer getProNumber() {
+        return proNumber;
+    }
+
+    public void setProNumber(Integer proNumber) {
+        this.proNumber = proNumber;
+    }
+
+    public Integer getUserNumber() {
+        return userNumber;
+    }
+
+    public void setUserNumber(Integer userNumber) {
+        this.userNumber = userNumber;
+    }
+
+    public String getProIntroduce() {
+        return proIntroduce;
+    }
+
+    public void setProIntroduce(String proIntroduce) {
+        this.proIntroduce = proIntroduce;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/member/repository/UserLoginHistoryRepository.java
+++ b/src/main/java/swyp/swyp6_team7/member/repository/UserLoginHistoryRepository.java
@@ -1,0 +1,17 @@
+package swyp.swyp6_team7.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import swyp.swyp6_team7.member.entity.UserLoginHistory;
+import swyp.swyp6_team7.member.entity.Users;
+
+import java.util.Optional;
+
+public interface UserLoginHistoryRepository extends JpaRepository<UserLoginHistory, Integer> {
+    Optional<UserLoginHistory> findTopByUserOrderByHisLoginDateDesc(Users user);
+
+    @Query("SELECT h FROM UserLoginHistory h WHERE h.user = :user ORDER BY h.hisLoginDate DESC")
+    Optional<UserLoginHistory> findLastLoginHistory(@Param("user") Users user);
+
+}

--- a/src/main/java/swyp/swyp6_team7/member/repository/UserProfileRepository.java
+++ b/src/main/java/swyp/swyp6_team7/member/repository/UserProfileRepository.java
@@ -1,0 +1,10 @@
+package swyp.swyp6_team7.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.swyp6_team7.member.entity.UserProfile;
+
+import java.util.Optional;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Integer> {
+    Optional<UserProfile> findByUserNumber(Integer userNumber);
+}

--- a/src/main/java/swyp/swyp6_team7/member/service/MemberService.java
+++ b/src/main/java/swyp/swyp6_team7/member/service/MemberService.java
@@ -11,9 +11,17 @@ import swyp.swyp6_team7.member.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import swyp.swyp6_team7.profile.dto.ProfileCreateRequest;
+import swyp.swyp6_team7.profile.service.ProfileService;
+
+import org.springframework.security.core.GrantedAuthority;
+import swyp.swyp6_team7.tag.service.TagService;
+
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class MemberService {
@@ -22,11 +30,21 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
+    private final ProfileService profileService;
+    private final TagService tagService;
+
+    private final String adminSecretKey = "tZ37HBGNyfUZVzgXGiv1OEBHvmgCyVB7";
+
+
     @Autowired
-    public MemberService(UserRepository userRepository, PasswordEncoder passwordEncoder, @Lazy JwtProvider jwtProvider) {
+
+    public MemberService(UserRepository userRepository, PasswordEncoder passwordEncoder, ProfileService profileService, @Lazy JwtProvider jwtProvider,TagService tagService){
+
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtProvider = jwtProvider;
+        this.profileService = profileService;
+        this.tagService = tagService;
     }
 
     @Transactional(readOnly = true)
@@ -37,39 +55,65 @@ public class MemberService {
 
     public Map<String, Object> signUp(UserRequestDto userRequestDto) {
 
+        // 이메일 중복 체크
+        if (userRepository.findByUserEmail(userRequestDto.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        // 태그 개수 검증 - 최대 5개까지 허용
+        if (userRequestDto.getPreferredTags().size() > 5) {
+            throw new IllegalArgumentException("태그는 최대 5개까지만 선택할 수 있습니다.");
+        }
+
         // Argon2로 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(userRequestDto.getPassword());
-
-        // 전화번호 포맷팅 (000-0000-0000 형식으로 변환)
-        String formattedPhoneNumber = formatPhoneNumber(userRequestDto.getPhone());
 
         // 성별 ENUM 변환
         Users.Gender gender = Users.Gender.valueOf(userRequestDto.getGender().toUpperCase());
 
+        // 연령대 ENUM 변환 및 검증
+        Users.AgeGroup ageGroup;
+        try {
+            ageGroup =  Users.AgeGroup.fromValue(userRequestDto.getAgegroup());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid age group provided.");
+        }
+
         // 기본 상태를 ABLE로 설정 (회원 상태 ENUM 사용)
         Users.MemberStatus status = Users.MemberStatus.ABLE;
 
-        // 성별 변환
-        Users.Gender convertedgender = Users.Gender.valueOf(userRequestDto.getGender().toUpperCase());
+        Users.UserRole role = Users.UserRole.USER;
+
+
         // Users 객체에 암호화된 비밀번호 설정
         Users newUser = Users.builder()
                 .userEmail(userRequestDto.getEmail())
                 .userPw(encodedPassword)  // 암호화된 비밀번호 설정
                 .userName(userRequestDto.getName())
-                .userPhone(formattedPhoneNumber)
-                .userGender(convertedgender)
-                .userBirthYear(userRequestDto.getBirthYear())
-                .roles(List.of("ROLE_USER"))  // 기본 역할 설정
+                .userGender(gender)
+                .userAgeGroup(ageGroup)
+                .role(role) // 기본 역할 설정
                 .userStatus(status)  // 기본 사용자 상태 설정
+                .preferredTags(tagService.createTags(userRequestDto.getPreferredTags())) // 태그 처리
                 .build();
-        newUser.setPassword(encodedPassword);
+
 
         // 사용자 저장
         userRepository.save(newUser);
 
+
+        // 프로필 생성 요청
+        ProfileCreateRequest profileCreateRequest = new ProfileCreateRequest();
+        profileCreateRequest.setUserNumber(newUser.getUserNumber());
+        profileService.createProfile(profileCreateRequest);
+
+        // 역할을 리스트로 변환하여 JWT 생성 시 전달
+        List<String> roles = List.of(newUser.getRole().name());  // ENUM을 String으로 변환하여 List로 만들기
+
+
         // JWT 발급
         long tokenExpirationTime = 3600000; // 토큰 만료 시간 추가(1시간)
-        String token = jwtProvider.createToken(newUser.getEmail(), newUser.getRoles(), tokenExpirationTime);
+        String token = jwtProvider.createToken(newUser.getEmail(), roles, tokenExpirationTime);
 
         // 응답 데이터에 userId와 accessToken 포함
         Map<String, Object> response = new HashMap<>();
@@ -80,10 +124,64 @@ public class MemberService {
         return response;
     }
 
-    public String formatPhoneNumber(String phoneNumber) {
-        // 숫자만 남기고 000-0000-0000 형식으로 변환
-        phoneNumber = phoneNumber.replaceAll("[^0-9]", "");
-        return phoneNumber.replaceFirst("(\\d{3})(\\d{4})(\\d+)", "$1-$2-$3");
+    // 관리자 생성 메서드
+    @Transactional
+    public Map<String, Object> createAdmin(UserRequestDto userRequestDto) {
+        // adminSecretKey 확인
+        if (!userRequestDto.getAdminSecretKey().equals(adminSecretKey)) {
+            throw new IllegalArgumentException("잘못된 관리자 시크릿 키입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(userRequestDto.getPassword());
+
+
+        // 성별 ENUM 변환
+        Users.Gender gender = Users.Gender.valueOf(userRequestDto.getGender().toUpperCase());
+
+        // 연령대 ENUM 변환 및 검증
+        Users.AgeGroup ageGroup;
+        try {
+            ageGroup = Users.AgeGroup.valueOf(userRequestDto.getAgegroup().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid age group provided.");
+        }
+
+        // 관리자 상태 및 역할 설정
+        Users.MemberStatus status = Users.MemberStatus.ABLE;
+
+
+        // 새로운 관리자 생성
+        Users newAdmin = Users.builder()
+                .userEmail(userRequestDto.getEmail())
+                .userPw(encodedPassword)
+                .userName(userRequestDto.getName())
+                .userGender(gender)
+                .userAgeGroup(ageGroup)
+                .role(Users.UserRole.ADMIN)
+                .userStatus(status)
+                .build();
+
+        // 관리자 저장
+        userRepository.save(newAdmin);
+
+        // 권한을 String으로 변환하여 리스트로 만들기
+        List<String> roles = newAdmin.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        // JWT 발급
+        long tokenExpirationTime = 3600000; // 토큰 만료 시간 1시간
+        String token = jwtProvider.createToken(newAdmin.getUserEmail(), roles, tokenExpirationTime);
+
+        // 응답 데이터
+        Map<String, Object> response = new HashMap<>();
+        response.put("userNumber", newAdmin.getUserNumber());
+        response.put("email", newAdmin.getUserEmail());
+        response.put("accessToken", token);
+
+        return response;
+
     }
 
     // 이메일 중복 확인 로직
@@ -92,5 +190,19 @@ public class MemberService {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
         return false; // 중복된 이메일이 없을 경우 false반환
+    }
+    @Transactional
+    public void updateLoginDate(Users user) {
+        user.setUserLoginDate(LocalDateTime.now());  // 현재 시간을 로그인 시간으로 설정
+        userRepository.save(user);  // 업데이트된 사용자 정보 저장
+    }
+    @Transactional
+    public void updateLogoutDate(Users user) {
+        user.setUserLogoutDate(LocalDateTime.now());  // 현재 시간을 로그아웃 시간으로 설정
+        userRepository.save(user);  // 업데이트된 사용자 정보 저장
+    }
+    public Users getUserByEmail(String email) {
+        return userRepository.findByUserEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다: " + email));
     }
 }

--- a/src/main/java/swyp/swyp6_team7/member/service/UserLoginHistoryService.java
+++ b/src/main/java/swyp/swyp6_team7/member/service/UserLoginHistoryService.java
@@ -1,0 +1,46 @@
+package swyp.swyp6_team7.member.service;
+
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Service;
+import swyp.swyp6_team7.member.entity.UserLoginHistory;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.repository.UserLoginHistoryRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class UserLoginHistoryService {
+
+    private final UserLoginHistoryRepository userLoginHistoryRepository;
+
+    public UserLoginHistoryService(UserLoginHistoryRepository userLoginHistoryRepository) {
+        this.userLoginHistoryRepository = userLoginHistoryRepository;
+    }
+
+    @Transactional
+    public void saveLoginHistory(Users user) {
+        System.out.println("로그인 이력 저장 시도: " + user.getUserEmail()); // 로그인 시도하는 유저 이메일 로그 출력
+        UserLoginHistory loginHistory = new UserLoginHistory();
+        loginHistory.setUser(user);
+        loginHistory.setHisLoginDate(LocalDateTime.now());
+        userLoginHistoryRepository.save(loginHistory);  // 로그인 시 이력 저장
+        System.out.println("로그인 이력 저장 완료"); // 저장 완료 로그 출력
+    }
+
+    @Transactional
+    public void updateLogoutHistory(Users user) {
+        // 마지막 로그인 기록을 찾아 로그아웃 시간을 업데이트
+        Optional<UserLoginHistory> lastLoginOpt = userLoginHistoryRepository
+                .findTopByUserOrderByHisLoginDateDesc(user);
+
+        if (lastLoginOpt.isPresent()) {
+            UserLoginHistory lastLogin = lastLoginOpt.get();
+            if (lastLogin.getHisLogoutDate() == null) {  // 아직 로그아웃 기록이 없는 경우만 처리
+                lastLogin.setHisLogoutDate(LocalDateTime.now());
+                userLoginHistoryRepository.save(lastLogin);  // 로그아웃 시간 업데이트
+            }
+        }
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/notice/controller/NoticeController.java
+++ b/src/main/java/swyp/swyp6_team7/notice/controller/NoticeController.java
@@ -1,0 +1,52 @@
+package swyp.swyp6_team7.notice.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import swyp.swyp6_team7.notice.dto.NoticeRequestDto;
+import swyp.swyp6_team7.notice.dto.NoticeResponseDto;
+import swyp.swyp6_team7.notice.entity.Notice;
+import swyp.swyp6_team7.notice.service.NoticeService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notices")
+public class NoticeController {
+    private final NoticeService noticeService;
+
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<NoticeResponseDto>> getAllNotices() {
+        return ResponseEntity.ok(noticeService.getAllNotices());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NoticeResponseDto> getNoticeById(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(noticeService.getNoticeById(id));
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PostMapping
+    public ResponseEntity<NoticeResponseDto> createNotice(@RequestBody NoticeRequestDto noticeRequestDto) {
+        return ResponseEntity.status(201).body(noticeService.createNotice(noticeRequestDto));
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{id}")
+    public ResponseEntity<NoticeResponseDto> updateNotice(
+            @PathVariable("id") Long id, @RequestBody NoticeRequestDto noticeRequestDto) {
+        return ResponseEntity.ok(noticeService.updateNotice(id, noticeRequestDto));
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNotice(@PathVariable("id") Long id) {
+        noticeService.deleteNotice(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/notice/dto/NoticeRequestDto.java
+++ b/src/main/java/swyp/swyp6_team7/notice/dto/NoticeRequestDto.java
@@ -1,0 +1,18 @@
+package swyp.swyp6_team7.notice.dto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeRequestDto {
+    private String title;
+    private String content;
+
+    // 생성자
+    public NoticeRequestDto(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/notice/dto/NoticeResponseDto.java
+++ b/src/main/java/swyp/swyp6_team7/notice/dto/NoticeResponseDto.java
@@ -1,0 +1,27 @@
+package swyp.swyp6_team7.notice.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdDate;
+    private int viewCount;
+
+    // 생성자
+    public NoticeResponseDto(Long id, String title, String content, LocalDateTime createdDate, int viewCount) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdDate = createdDate;
+        this.viewCount = viewCount;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/notice/entity/Notice.java
+++ b/src/main/java/swyp/swyp6_team7/notice/entity/Notice.java
@@ -1,0 +1,33 @@
+package swyp.swyp6_team7.notice.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Table(name = "Notices")
+public class Notice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long noticeId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    @Column(nullable = false)
+    private int viewCount;
+}

--- a/src/main/java/swyp/swyp6_team7/notice/repository/NoticeRepository.java
+++ b/src/main/java/swyp/swyp6_team7/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package swyp.swyp6_team7.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.swyp6_team7.notice.entity.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long>{
+}

--- a/src/main/java/swyp/swyp6_team7/notice/service/NoticeService.java
+++ b/src/main/java/swyp/swyp6_team7/notice/service/NoticeService.java
@@ -1,0 +1,92 @@
+package swyp.swyp6_team7.notice.service;
+
+import org.springframework.stereotype.Service;
+import swyp.swyp6_team7.notice.dto.NoticeRequestDto;
+import swyp.swyp6_team7.notice.dto.NoticeResponseDto;
+import swyp.swyp6_team7.notice.entity.Notice;
+import swyp.swyp6_team7.notice.repository.NoticeRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    public NoticeService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    // 전체 공지사항 조회
+    public List<NoticeResponseDto> getAllNotices() {
+        // Notice 엔티티를 NoticeResponseDto로 변환하여 반환
+        return noticeRepository.findAll().stream()
+                .map(notice -> new NoticeResponseDto(
+                        notice.getNoticeId(),
+                        notice.getTitle(),
+                        notice.getContent(),
+                        notice.getCreatedDate(),
+                        notice.getViewCount()
+                ))
+                .collect(Collectors.toList()); // 변환된 리스트를 수집하여 반환
+    }
+
+    // ID로 공지사항 조회
+    public NoticeResponseDto getNoticeById(Long id) {
+        Notice notice = noticeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Notice not found"));
+        return new NoticeResponseDto(notice.getNoticeId(), notice.getTitle(), notice.getContent(), notice.getCreatedDate(), notice.getViewCount());
+    }
+
+    // 공지사항 생성
+    public NoticeResponseDto createNotice(NoticeRequestDto noticeRequestDto) {
+        // 새로운 Notice 엔티티 생성 후 값 설정
+        Notice notice = new Notice();
+        notice.setTitle(noticeRequestDto.getTitle());
+        notice.setContent(noticeRequestDto.getContent());
+        notice.setCreatedDate(LocalDateTime.now()); // 생성일 현재 시간으로 설정
+
+        // Notice 엔티티를 저장
+        Notice savedNotice = noticeRepository.save(notice);
+
+        // 저장된 공지사항을 NoticeResponseDto로 변환하여 반환
+        return new NoticeResponseDto(
+                savedNotice.getNoticeId(),
+                savedNotice.getTitle(),
+                savedNotice.getContent(),
+                savedNotice.getCreatedDate(),
+                savedNotice.getViewCount()
+        );
+    }
+
+
+    // 공지사항 수정
+    public NoticeResponseDto updateNotice(Long id, NoticeRequestDto noticeRequestDto) {
+        // 수정할 공지사항을 ID로 조회
+        Notice existingNotice = noticeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Notice not found"));
+
+        // 제목과 내용을 요청된 값으로 업데이트
+        existingNotice.setTitle(noticeRequestDto.getTitle());
+        existingNotice.setContent(noticeRequestDto.getContent());
+
+        // 업데이트된 공지사항 저장
+        Notice updatedNotice = noticeRepository.save(existingNotice);
+
+        // 수정된 공지사항을 NoticeResponseDto로 변환하여 반환
+        return new NoticeResponseDto(
+                updatedNotice.getNoticeId(),
+                updatedNotice.getTitle(),
+                updatedNotice.getContent(),
+                updatedNotice.getCreatedDate(),
+                updatedNotice.getViewCount()
+        );
+    }
+
+
+    // 공지사항 삭제
+    public void deleteNotice(Long id) {
+        noticeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/profile/controller/ProfileController.java
+++ b/src/main/java/swyp/swyp6_team7/profile/controller/ProfileController.java
@@ -1,0 +1,73 @@
+package swyp.swyp6_team7.profile.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import swyp.swyp6_team7.member.entity.UserProfile;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.repository.UserProfileRepository;
+import swyp.swyp6_team7.profile.dto.ProfileCreateRequest;
+import swyp.swyp6_team7.profile.dto.ProfileUpdateRequest;
+import swyp.swyp6_team7.profile.service.ProfileService;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/profile")
+public class ProfileController {
+    private final ProfileService profileService;
+    private final UserProfileRepository userProfileRepository;
+
+    public ProfileController(ProfileService profileService,UserProfileRepository userProfileRepository) {
+        this.profileService = profileService;
+        this.userProfileRepository = userProfileRepository;
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> updateProfile(@RequestBody ProfileUpdateRequest request) {
+        System.out.println("Request Body: " + request);
+
+        profileService.updateProfile(request);
+        return ResponseEntity.ok("Profile updated successfully");
+    }
+    @PostMapping("/create")
+    public ResponseEntity<String> createProfile(@RequestBody ProfileCreateRequest request) {
+        profileService.createProfile(request);
+        return ResponseEntity.ok("프로필이 생성되었습니다.");
+    }
+    @GetMapping("/me")
+    public ResponseEntity<?> viewProfile(@RequestParam("userNumber")  Integer userNumber) {
+        Optional<Users> user = profileService.getUserByUserNumber(userNumber);
+        Optional<UserProfile> userProfile = profileService.getProfileByUserNumber(userNumber);
+
+        if (user.isEmpty()) {
+            return ResponseEntity.status(404).body("User not found");
+        }
+
+        if (userProfile.isEmpty()) {
+            return ResponseEntity.status(404).body("User profile not found");
+        }
+
+        // 필요한 사용자 정보와 프로필 정보 반환
+        return ResponseEntity.ok(new ProfileViewResponse(user.get(), userProfile.get()));
+    }
+
+    // 프로필 보기 응답 객체
+    public static class ProfileViewResponse {
+        private String name;
+        private String proIntroduce;
+
+        public ProfileViewResponse(Users user, UserProfile userProfile) {
+            this.name = user.getUserName();
+            this.proIntroduce = userProfile.getProIntroduce();
+        }
+
+        // Getters
+        public String getName() {
+            return name;
+        }
+
+        public String getProIntroduce() {
+            return proIntroduce;
+        }
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/profile/dto/ProfileCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/profile/dto/ProfileCreateRequest.java
@@ -1,0 +1,13 @@
+package swyp.swyp6_team7.profile.dto;
+
+public class ProfileCreateRequest {
+    private Integer userNumber;
+
+    public Integer getUserNumber() {
+        return userNumber;
+    }
+
+    public void setUserNumber(Integer userNumber) {
+        this.userNumber = userNumber;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/profile/dto/ProfileUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/profile/dto/ProfileUpdateRequest.java
@@ -1,0 +1,31 @@
+package swyp.swyp6_team7.profile.dto;
+
+public class ProfileUpdateRequest {
+    private Integer userNumber;
+    private String name;;
+    private String proIntroduce;
+
+    public Integer getUserNumber() {
+        return userNumber;
+    }
+
+    public void setUserNumber(Integer userNumber) {
+        this.userNumber = userNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProIntroduce() {
+        return proIntroduce;
+    }
+
+    public void setProIntroduce(String proIntroduce) {
+        this.proIntroduce = proIntroduce;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/profile/service/ProfileService.java
+++ b/src/main/java/swyp/swyp6_team7/profile/service/ProfileService.java
@@ -1,0 +1,65 @@
+package swyp.swyp6_team7.profile.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.repository.UserProfileRepository;
+import swyp.swyp6_team7.member.entity.UserProfile;
+import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.profile.dto.ProfileCreateRequest;
+import swyp.swyp6_team7.profile.dto.ProfileUpdateRequest;
+
+import java.util.Optional;
+
+@Service
+public class ProfileService {
+    private final UserProfileRepository userProfileRepository;
+    private final UserRepository userRepository;
+
+    public ProfileService(UserProfileRepository userProfileRepository,UserRepository userRepository) {
+        this.userProfileRepository = userProfileRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void createProfile(ProfileCreateRequest profileCreateRequest) {
+        // 프로필 엔티티 생성
+        UserProfile userProfile = new UserProfile();
+        userProfile.setUserNumber(profileCreateRequest.getUserNumber());
+
+        // 프로필 저장
+        userProfileRepository.save(userProfile);
+    }
+
+    @Transactional
+    public void updateProfile(ProfileUpdateRequest request) {
+        System.out.println("Request received for user number: " + request.getUserNumber());
+        Optional<UserProfile> userProfileOpt = userProfileRepository.findByUserNumber(request.getUserNumber());
+        if (userProfileOpt.isEmpty()) {
+            throw new IllegalArgumentException("프로필이 존재하지 않습니다. 새 프로필을 생성해주세요.");
+        }
+        UserProfile userProfile = userProfileOpt.get();  // 이미 조회한 값을 가져옵니다.
+
+        // 프로필 정보 수정
+        userProfile.setProIntroduce(request.getProIntroduce());
+
+        userProfileRepository.save(userProfile);  // DB에 저장
+        // Users 업데이트
+        Optional<Users> usersOpt = userRepository.findById(request.getUserNumber());
+        if (usersOpt.isPresent()) {
+            Users user = usersOpt.get();
+            user.setUserName(request.getName());       // name 업데이트
+            userRepository.save(user);            // Users 저장
+        } else {
+            throw new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+        }
+    }
+
+    public Optional<UserProfile> getProfileByUserNumber(Integer userNumber) {
+        return userProfileRepository.findByUserNumber(userNumber);
+    }
+
+    public Optional<Users> getUserByUserNumber(Integer userNumber) {
+        return userRepository.findById(userNumber);
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/tag/service/TagService.java
+++ b/src/main/java/swyp/swyp6_team7/tag/service/TagService.java
@@ -6,6 +6,9 @@ import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.repository.TagRepository;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -17,6 +20,15 @@ public class TagService {
     public Tag findByName(String name) {
         return tagRepository.findByName(name)
                 .orElseGet(() -> tagRepository.save(Tag.of(name)));
+    }
+
+    @Transactional
+    public List<Tag> createTags(List<String> tagNames) {
+        // 태그 이름 리스트에서 각 태그를 찾거나 생성
+        return tagNames.stream()
+                .distinct()  // 중복 제거
+                .map(this::findByName)  // 각 태그 이름을 통해 태그를 찾거나 생성
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -9,7 +9,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.response.TravelRecommendResponse;
 import swyp.swyp6_team7.travel.service.TravelHomeService;
+
+import java.security.Principal;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -31,4 +35,15 @@ public class TravelHomeController {
                 .body(result);
     }
 
+    @GetMapping("/api/travels/recommend")
+    public ResponseEntity<List<TravelRecommendResponse>> getRecommendTravels(Principal principal) {
+
+        List<TravelRecommendResponse> result = travelHomeService.getRecommendTravelsByUser(principal)
+                .stream()
+                .map(dto -> new TravelRecommendResponse(dto))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(result);
+    }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
@@ -1,0 +1,88 @@
+package swyp.swyp6_team7.travel.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swyp.swyp6_team7.travel.domain.Travel;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TravelRecommendDto {
+
+    private static final int RECOMMEND_TAG_MAX_NUMBER = 3;
+
+    @NotNull
+    private int travelNumber;
+    private String title;
+    private int userNumber;
+    private String userName;
+    private List<String> tags;
+    private int nowPerson;
+    private int maxPerson;
+    private LocalDateTime createdAt;
+    private LocalDate registerDue;
+    private int preferredNumber;
+
+    @Builder
+    public TravelRecommendDto(
+            int travelNumber, String title, int userNumber, String userName,
+            List<String> tags, int nowPerson, int maxPerson,
+            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber
+    ) {
+        this.travelNumber = travelNumber;
+        this.title = title;
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.tags = tags;
+        this.nowPerson = nowPerson;
+        this.maxPerson = maxPerson;
+        this.createdAt = createdAt;
+        this.registerDue = registerDue;
+        this.preferredNumber = preferredNumber;
+    }
+
+    @QueryProjection
+    public TravelRecommendDto(
+            Travel travel, int userNumber, String userName,
+            List<String> tags
+    ) {
+        this.travelNumber = travel.getNumber();
+        this.title = travel.getTitle();
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.tags = tags.stream()
+                .limit(RECOMMEND_TAG_MAX_NUMBER).toList();
+        this.nowPerson = 1; //TODO: 현재 신청 완료 인원수
+        this.maxPerson = travel.getMaxPerson();
+        this.createdAt = travel.getCreatedAt();
+        this.registerDue = travel.getDueDate();
+    }
+
+    public void updatePreferredNumber(Integer number) {
+        this.preferredNumber = number;
+    }
+
+    @Override
+    public String toString() {
+        return "TravelRecommendDto{" +
+                "travelNumber=" + travelNumber +
+                ", title='" + title + '\'' +
+                ", userNumber=" + userNumber +
+                ", userName='" + userName + '\'' +
+                ", tags=" + tags +
+                ", nowPerson=" + nowPerson +
+                ", maxPerson=" + maxPerson +
+                ", createdAt=" + createdAt +
+                ", registerDue=" + registerDue +
+                ", preferredNumber=" + preferredNumber +
+                '}';
+    }
+}
+

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
@@ -1,0 +1,43 @@
+package swyp.swyp6_team7.travel.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TravelRecommendResponse {
+
+    @NotNull
+    private int travelNumber;
+    private String title;
+    private int userNumber;
+    private String userName;
+    private List<String> tags;
+    private int nowPerson;
+    private int maxPerson;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    private LocalDate registerDue;
+
+    public TravelRecommendResponse(TravelRecommendDto dto) {
+        this.travelNumber = dto.getTravelNumber();
+        this.title = dto.getTitle();
+        this.userNumber = dto.getUserNumber();
+        this.userName = dto.getUserName();
+        this.tags = dto.getTags();
+        this.nowPerson = dto.getNowPerson();
+        this.maxPerson = dto.getMaxPerson();
+        this.createdAt = dto.getCreatedAt();
+        this.registerDue = dto.getRegisterDue();
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -5,11 +5,16 @@ import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+
+import java.util.List;
 
 public interface TravelCustomRepository {
 
     Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest);
+
+    List<TravelRecommendDto> findAllByPreferredTags(List<String> preferredTags);
 
     Page<TravelSearchDto> search(TravelSearchCondition condition);
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
@@ -1,22 +1,42 @@
 package swyp.swyp6_team7.travel.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
+import swyp.swyp6_team7.travel.util.TravelRecommendComparator;
 
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class TravelHomeService {
 
     private final TravelRepository travelRepository;
+    private final MemberService memberService;
 
     public Page<TravelRecentDto> getTravelsSortedByCreatedAt(PageRequest pageRequest) {
         return travelRepository.findAllSortedByCreatedAt(pageRequest);
     }
 
+    public List<TravelRecommendDto> getRecommendTravelsByUser(Principal principal) {
+
+        List<String> preferredTags = memberService.findPreferredTagsByEmail(principal.getName());
+        log.info("preferredTags: " + preferredTags);
+
+        List<TravelRecommendDto> result = travelRepository.findAllByPreferredTags(preferredTags);
+        Collections.sort(result, new TravelRecommendComparator());
+
+        return result;
+    }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
@@ -1,0 +1,17 @@
+package swyp.swyp6_team7.travel.util;
+
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+
+import java.util.Comparator;
+
+public class TravelRecommendComparator implements Comparator<TravelRecommendDto> {
+
+    @Override
+    public int compare(TravelRecommendDto o1, TravelRecommendDto o2) {
+        if (o1.getPreferredNumber() == o2.getPreferredNumber()) {
+            return o1.getRegisterDue().compareTo(o2.getRegisterDue());
+        }
+        return -1 * (o1.getPreferredNumber() - o2.getPreferredNumber());
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,5 @@ custom:
   jwt:
     secretKey: oRzn5UpJmgRXxtOLMBG+jNhz2aAjPXHESKdjz4hFea5GNLnB9bVeVXKxKcZtxU+DlGZ4nHGO7xrXYhTkEhe2Zg==
     expirationMs: 3600000 # 토큰 만료 시간 (1시간 = 3600000ms)
+
+  admin-secret-key: tZ37HBGNyfUZVzgXGiv1OEBHvmgCyVB7

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -27,7 +27,6 @@ import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,15 +69,10 @@ class TravelControllerTest {
                 .userPw("1234")
                 .userName("username")
                 .userGender(Users.Gender.M)
-                .userBirthYear("2000")
-                .userPhone("01012345678")
-                .userRole("user")
+                .userAgeGroup(Users.AgeGroup.TEEN)
                 .userRegDate(LocalDateTime.now())
                 .userStatus(Users.MemberStatus.ABLE)
                 .build());
-        List<String> roles = new ArrayList<>();
-        roles.add("ROLE_USER");
-        user.setRoles(roles);
 
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(new UsernamePasswordAuthenticationToken(user, user.getUserPw(), user.getAuthorities()));

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -66,8 +66,7 @@ class TravelCustomRepositoryImplTest {
                 .userPw("1234")
                 .userName("모잉")
                 .userGender(Users.Gender.M)
-                .userBirthYear("2000")
-                .userPhone("01012345678")
+                .userAgeGroup(Users.AgeGroup.TEEN)
                 .userRegDate(LocalDateTime.now())
                 .userStatus(Users.MemberStatus.ABLE)
                 .build());

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -32,8 +32,7 @@ class TravelServiceTest {
                 .userPw("1234")
                 .userName("username")
                 .userGender(Users.Gender.M)
-                .userBirthYear("2000")
-                .userPhone("01012345678")
+                .userAgeGroup(Users.AgeGroup.TEEN)
                 .userRegDate(LocalDateTime.now())
                 .userStatus(Users.MemberStatus.ABLE)
                 .build();

--- a/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
@@ -1,0 +1,58 @@
+package swyp.swyp6_team7.travel.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TravelRecommendComparatorTest {
+
+    @DisplayName("compareTo: preferredNumber가 큰 쪽이 더 작다")
+    @Test
+    public void compareTo() {
+        // given
+        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+                .preferredNumber(1)
+                .build();
+        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+                .preferredNumber(5)
+                .build();
+        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+
+        // when
+        Collections.sort(result, new TravelRecommendComparator());
+
+        // then
+        assertThat(result.get(0)).isEqualTo(dto2);
+        assertThat(result.get(1)).isEqualTo(dto1);
+    }
+
+    @DisplayName("compareTo: preferredNumber가 같으면 RegisterDue가 작은 쪽(현재와 가까운)이 더 작다")
+    @Test
+    public void compareToWhenPreferredNumberSame() {
+        // given
+        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+                .preferredNumber(5)
+                .registerDue(LocalDate.now().plusDays(5))
+                .build();
+        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+                .preferredNumber(5)
+                .registerDue(LocalDate.now().plusDays(1))
+                .build();
+        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+
+        // when
+        Collections.sort(result, new TravelRecommendComparator());
+
+        // then
+        assertThat(result.get(0)).isEqualTo(dto2);
+        assertThat(result.get(1)).isEqualTo(dto1);
+    }
+
+}


### PR DESCRIPTION
## 🔗 Issue Number
feat: 추천 여행 콘텐츠 목록 #18

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
사용자가 설정해둔 선호 태그와 여행 콘텐츠의 태그 일치 정도를 이용한다
추천 로직 조건은 3가지이나, 우선 앞의 2가지만 적용해 구현함
선호도가 많이 일치하는 순 / 마감 시간이 가까운 순 / ㄱㄴㄷ 자음 순으로 정렬

Repository 단에서 선호도 일치, 마감시간 정렬을 진행해 Travel 콘텐츠의 number를 가져오는 부분까지는 쉽게 구현함.
Travel의 number 리스트를 바탕으로 DTO를 만들 때 정렬의 group by와 transform의 group by가 충돌하는 문제
우선 필요한 데이터와 공통 태그의 개수를 함께 DTO에 저장해 서비스단으로 가져와 애플리케이션에서 재정렬하도록 구현함
이를 위해 TravelRecommendComparator를 추가


## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
