### PR TITLE
feat(travel): 여행콘텐츠 추천목록 가나다순 정렬 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
@@ -9,6 +9,9 @@ public class TravelRecommendComparator implements Comparator<TravelRecommendDto>
     @Override
     public int compare(TravelRecommendDto o1, TravelRecommendDto o2) {
         if (o1.getPreferredNumber() == o2.getPreferredNumber()) {
+            if (o1.getRegisterDue().compareTo(o2.getRegisterDue()) == 0) {
+                return o1.getTitle().compareTo(o2.getTitle());
+            }
             return o1.getRegisterDue().compareTo(o2.getRegisterDue());
         }
         return -1 * (o1.getPreferredNumber() - o2.getPreferredNumber());

--- a/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
@@ -55,4 +55,28 @@ class TravelRecommendComparatorTest {
         assertThat(result.get(1)).isEqualTo(dto1);
     }
 
+    @DisplayName("compareTo: preferredNumber, RegisterDue가 같으면 제목순으로 오름차순 정렬한다")
+    @Test
+    public void compareToWhenDueDateSame() {
+        // given
+        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+                .title("나")
+                .preferredNumber(5)
+                .registerDue(LocalDate.now().plusDays(5))
+                .build();
+        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+                .title("가다")
+                .preferredNumber(5)
+                .registerDue(LocalDate.now().plusDays(5))
+                .build();
+        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+
+        // when
+        Collections.sort(result, new TravelRecommendComparator());
+
+        // then
+        assertThat(result.get(0)).isEqualTo(dto2);
+        assertThat(result.get(1)).isEqualTo(dto1);
+    }
+
 }


### PR DESCRIPTION
## 🔗 Issue Number
feat: 추천 여행 콘텐츠 목록 #18

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
메인 페이지의 추천 여행 콘텐츠 목록 api의 마지막 정렬 조건을 추가했다.
공통태그 개수가 많은 순서 -> 마감날짜가 가까운 순서 -> 제목 가나다순서
총 3가지의 기준으로 정렬을 진행하게 된다.


## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
