### PR TITLE
feat: 참가 신청 관련 알림 생성 및 목록 조회 기능

### DIFF
--- a/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
+++ b/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @EnableJpaAuditing
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+@EnableAsync
 @SpringBootApplication
 public class Swyp6Team7Application {
 

--- a/src/main/java/swyp/swyp6_team7/enrollment/dto/EnrollmentResponse.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/dto/EnrollmentResponse.java
@@ -19,7 +19,7 @@ public class EnrollmentResponse {
     private long enrollmentNumber;
     private String userName;
     private String userAgeGroup;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime enrolledAt;
     private String message;
     private String status;

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -13,9 +13,7 @@ import swyp.swyp6_team7.enrollment.dto.EnrollmentResponse;
 import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.service.MemberService;
-import swyp.swyp6_team7.notification.entity.Notification;
-import swyp.swyp6_team7.notification.repository.NotificationRepository;
-import swyp.swyp6_team7.notification.util.NotificationMaker;
+import swyp.swyp6_team7.notification.service.NotificationService;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.response.TravelEnrollmentsResponse;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
@@ -31,8 +29,9 @@ public class EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
     private final TravelRepository travelRepository;
     private final CompanionRepository companionRepository;
-    private final NotificationRepository notificationRepository;
+
     private final MemberService memberService;
+    private final NotificationService notificationService;
 
 
     @Transactional
@@ -49,9 +48,7 @@ public class EnrollmentService {
         enrollmentRepository.save(created);
 
         //알림
-        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel, user);
-        newNotification = notificationRepository.save(newNotification);
-        log.info("참가 신청 알림 생성: " + newNotification.toString());
+        notificationService.createEnrollNotificaton(targetTravel, user);
     }
 
     @Transactional
@@ -93,9 +90,7 @@ public class EnrollmentService {
         companionRepository.save(newCompanion);
 
         //알림
-        Notification newNotification = NotificationMaker.travelAcceptMessage(targetTravel, enrollment);
-        newNotification = notificationRepository.save(newNotification);
-        log.info("신청 수락 알림 생성: " + newNotification.toString());
+        notificationService.createAcceptNotification(targetTravel, enrollment);
     }
 
     @Transactional
@@ -105,13 +100,11 @@ public class EnrollmentService {
         Travel targetTravel = travelRepository.findByNumber(enrollment.getTravelNumber())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행 콘텐츠입니다."));
         authorizeTravelHost(targetTravel);
-        
+
         enrollment.rejected();
 
         //알림
-        Notification newNotification = NotificationMaker.travelRejectMessage(targetTravel, enrollment);
-        newNotification = notificationRepository.save(newNotification);
-        log.info("신청 거절 알림 생성: " + newNotification.toString());
+        notificationService.createRejectNotification(targetTravel, enrollment);
     }
 
     private void authorizeEnrollmentOwner(Enrollment enrollment) {

--- a/src/main/java/swyp/swyp6_team7/notification/controller/NotificationController.java
+++ b/src/main/java/swyp/swyp6_team7/notification/controller/NotificationController.java
@@ -1,0 +1,28 @@
+package swyp.swyp6_team7.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.notification.dto.NotificationDto;
+import swyp.swyp6_team7.notification.service.NotificationService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+
+    @GetMapping("/api/notifications")
+    public ResponseEntity<List<NotificationDto>> getNotificationsByUser() {
+        List<NotificationDto> notifications = notificationService.getNotificationsByUser();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(notifications);
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/controller/NotificationController.java
+++ b/src/main/java/swyp/swyp6_team7/notification/controller/NotificationController.java
@@ -1,9 +1,12 @@
 package swyp.swyp6_team7.notification.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import swyp.swyp6_team7.notification.dto.NotificationDto;
 import swyp.swyp6_team7.notification.service.NotificationService;
@@ -18,9 +21,11 @@ public class NotificationController {
 
 
     @GetMapping("/api/notifications")
-    public ResponseEntity<List<NotificationDto>> getNotificationsByUser() {
-        List<NotificationDto> notifications = notificationService.getNotificationsByUser();
-
+    public ResponseEntity<Page<NotificationDto>> getNotificationsByUser(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        Page<NotificationDto> notifications = notificationService.getNotificationsByUser(PageRequest.of(page, size));
         return ResponseEntity.status(HttpStatus.OK)
                 .body(notifications);
     }

--- a/src/main/java/swyp/swyp6_team7/notification/dto/NotificationDto.java
+++ b/src/main/java/swyp/swyp6_team7/notification/dto/NotificationDto.java
@@ -1,0 +1,28 @@
+package swyp.swyp6_team7.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import swyp.swyp6_team7.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationDto {
+
+    private String title;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime createdAt;
+
+    private String content;
+
+    private Boolean isRead;
+
+
+    public NotificationDto(Notification notification) {
+        this.title = notification.getTitle();
+        this.createdAt = notification.getCreatedAt();
+        this.content = notification.getContent();
+        this.isRead = notification.getIsRead();
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
+++ b/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
@@ -1,0 +1,27 @@
+package swyp.swyp6_team7.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import swyp.swyp6_team7.notification.entity.TravelNotification;
+
+import java.time.LocalDate;
+
+@Getter
+public class TravelNotificationDto extends NotificationDto {
+
+    private Integer travelNumber;
+
+    private String travelTitle;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate travelDueDate;
+
+
+    public TravelNotificationDto(TravelNotification notification) {
+        super(notification);
+        this.travelNumber = notification.getTravelNumber();
+        this.travelTitle = notification.getTravelTitle();
+        this.travelDueDate = notification.getTravelDueDate();
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
@@ -1,0 +1,72 @@
+package swyp.swyp6_team7.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Table(name = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "notification_type")
+@Entity
+public abstract class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long number;
+
+    @CreatedDate
+    @Column(name = "notification_create_time", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "notification_receiver_number", nullable = false)
+    private Integer receiverNumber;
+
+    @Column(name = "notification_title")
+    private String title;
+
+    @Column(name = "notification_content")
+    private String content;
+
+    @Column(name = "notification_read", nullable = false)
+    private Boolean isRead;
+
+    //TODO: 이미지
+
+
+    public Notification(
+            Long number, LocalDateTime createdAt, Integer receiverNumber,
+            String title, String content, Boolean isRead
+    ) {
+        this.number = number;
+        this.createdAt = createdAt;
+        this.receiverNumber = receiverNumber;
+        this.title = title;
+        this.content = content;
+        this.isRead = isRead;
+    }
+
+    public void read() {
+        this.isRead = true;
+    }
+
+    @Override
+    public String toString() {
+        return "Notification{" +
+                "number=" + number +
+                ", createdAt=" + createdAt +
+                ", receiverNumber=" + receiverNumber +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", isRead=" + isRead +
+                '}';
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/entity/NotificationType.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/NotificationType.java
@@ -1,0 +1,16 @@
+package swyp.swyp6_team7.notification.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    TRAVEL_ENROLL("여행 참가 신청"),
+    TRAVEL_ACCEPT("여행 참가 신청"),
+    TRAVEL_REJECT("여행 참가 신청");
+
+    private final String title;
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
@@ -1,0 +1,58 @@
+package swyp.swyp6_team7.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@DiscriminatorValue("travel")
+public class TravelNotification extends Notification {
+
+    @Column(name = "travel_number", nullable = false)
+    private Integer travelNumber;
+
+    @Column(name = "travel_title")
+    private String travelTitle;
+
+    @Column(name = "travel_due_date")
+    private LocalDate travelDueDate;
+
+
+    @Builder
+    public TravelNotification(
+            Long number, LocalDateTime createdAt, Integer receiverNumber,
+            String title, String content, Boolean isRead,
+            Integer travelNumber, String travelTitle, LocalDate travelDueDate
+    ) {
+        super(number, createdAt, receiverNumber, title, content, isRead);
+        this.travelNumber = travelNumber;
+        this.travelTitle = travelTitle;
+        this.travelDueDate = travelDueDate;
+    }
+
+
+    @Override
+    public String toString() {
+        return "TravelNotification{" +
+                "number=" + super.getNumber() +
+                ", createdAt=" + super.getCreatedAt() +
+                ", receiverNumber=" + super.getReceiverNumber() +
+                ", title='" + super.getTitle() + '\'' +
+                ", content='" + super.getContent() + '\'' +
+                ", isRead=" + super.getIsRead() +
+                "travelNumber=" + travelNumber +
+                ", travelTitle='" + travelTitle + '\'' +
+                ", travelDueDate=" + travelDueDate +
+                '}';
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
+++ b/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
@@ -1,5 +1,7 @@
 package swyp.swyp6_team7.notification.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.swyp6_team7.notification.entity.Notification;
 
@@ -8,5 +10,7 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> getNotificationsByReceiverNumberOrderByCreatedAtDesc(int userNumber);
+
+    Page<Notification> getNotificationsByReceiverNumberOrderByCreatedAtDesc(int userNumber, Pageable pageable);
 
 }

--- a/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
+++ b/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package swyp.swyp6_team7.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.swyp6_team7.notification.entity.Notification;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> getNotificationsByReceiverNumberOrderByCreatedAtDesc(int userNumber);
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -1,9 +1,14 @@
 package swyp.swyp6_team7.notification.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.enrollment.domain.Enrollment;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.notification.dto.NotificationDto;
@@ -11,9 +16,13 @@ import swyp.swyp6_team7.notification.dto.TravelNotificationDto;
 import swyp.swyp6_team7.notification.entity.Notification;
 import swyp.swyp6_team7.notification.entity.TravelNotification;
 import swyp.swyp6_team7.notification.repository.NotificationRepository;
+import swyp.swyp6_team7.notification.util.NotificationMaker;
+import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.util.List;
 
+@Slf4j
+@Transactional
 @RequiredArgsConstructor
 @Service
 public class NotificationService {
@@ -22,17 +31,36 @@ public class NotificationService {
     private final MemberService memberService;
 
 
-    @Transactional
-    public List<NotificationDto> getNotificationsByUser() {
+    @Async
+    public void createEnrollNotificaton(Travel targetTravel, Users user) {
+        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel, user);
+        newNotification = notificationRepository.save(newNotification);
+        log.info("[알림] 참가신청 =" + newNotification.toString());
+    }
+
+    @Async
+    public void createAcceptNotification(Travel targetTravel, Enrollment enrollment) {
+        Notification newNotification = NotificationMaker.travelAcceptMessage(targetTravel, enrollment);
+        newNotification = notificationRepository.save(newNotification);
+        log.info("[알림] 신청수락 = " + newNotification.toString());
+    }
+
+    @Async
+    public void createRejectNotification(Travel targetTravel, Enrollment enrollment) {
+        Notification newNotification = NotificationMaker.travelRejectMessage(targetTravel, enrollment);
+        newNotification = notificationRepository.save(newNotification);
+        log.info("[알림] 신청거절 = " + newNotification.toString());
+    }
+
+
+    public Page<NotificationDto> getNotificationsByUser(PageRequest pageRequest) {
         String userName = SecurityContextHolder.getContext().getAuthentication().getName();
         Users user = memberService.findByEmail(userName);
 
-        List<Notification> notifications = notificationRepository
-                .getNotificationsByReceiverNumberOrderByCreatedAtDesc(user.getUserNumber());
+        Page<Notification> notifications = notificationRepository
+                .getNotificationsByReceiverNumberOrderByCreatedAtDesc(user.getUserNumber(), pageRequest);
 
-        return notifications.stream()
-                .map(notification -> makeDto(notification))
-                .toList();
+        return notifications.map(notification -> makeDto(notification));
     }
 
     private NotificationDto makeDto(Notification notification) {

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -1,0 +1,57 @@
+package swyp.swyp6_team7.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.service.MemberService;
+import swyp.swyp6_team7.notification.dto.NotificationDto;
+import swyp.swyp6_team7.notification.dto.TravelNotificationDto;
+import swyp.swyp6_team7.notification.entity.Notification;
+import swyp.swyp6_team7.notification.entity.TravelNotification;
+import swyp.swyp6_team7.notification.repository.NotificationRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberService memberService;
+
+
+    @Transactional
+    public List<NotificationDto> getNotificationsByUser() {
+        String userName = SecurityContextHolder.getContext().getAuthentication().getName();
+        Users user = memberService.findByEmail(userName);
+
+        List<Notification> notifications = notificationRepository
+                .getNotificationsByReceiverNumberOrderByCreatedAtDesc(user.getUserNumber());
+
+        return notifications.stream()
+                .map(notification -> makeDto(notification))
+                .toList();
+    }
+
+    private NotificationDto makeDto(Notification notification) {
+        NotificationDto result;
+
+        if (notification instanceof TravelNotification) {
+            TravelNotification travelNotification = (TravelNotification) notification;
+            result = new TravelNotificationDto(travelNotification);
+        } else {
+            result = new NotificationDto(notification);
+        }
+        changeReadStatus(notification);
+        return result;
+    }
+
+    private void changeReadStatus(Notification notification) {
+        if (!notification.getIsRead()) {
+            notification.read();
+        }
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -1,0 +1,48 @@
+package swyp.swyp6_team7.notification.util;
+
+import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.notification.entity.Notification;
+import swyp.swyp6_team7.notification.entity.NotificationType;
+import swyp.swyp6_team7.notification.entity.TravelNotification;
+import swyp.swyp6_team7.travel.domain.Travel;
+
+public class NotificationMaker {
+
+    public static Notification travelEnrollmentMessage(Travel targetTravel, Users user) {
+        return TravelNotification.builder()
+                .receiverNumber(targetTravel.getUserNumber())
+                .title(NotificationType.TRAVEL_ENROLL.getTitle())
+                .content(user.getUserName() + "님이 참가를 희망했어요.\n수락하시려면 눌러주세요.")
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelAcceptMessage(Travel targetTravel, Enrollment enrollment) {
+        return TravelNotification.builder()
+                .receiverNumber(enrollment.getUserNumber())
+                .title(NotificationType.TRAVEL_ACCEPT.getTitle())
+                .content("여행 신청이 수락되었어요.")
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelRejectMessage(Travel targetTravel, Enrollment enrollment) {
+        return TravelNotification.builder()
+                .receiverNumber(enrollment.getUserNumber())
+                .title(NotificationType.TRAVEL_REJECT.getTitle())
+                .content("여행 신청이 거절되었어요.\n다른 여행을 찾아보세요!")
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
+                .isRead(false)
+                .build();
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -19,7 +19,7 @@ public class TravelDetailResponse {
     private int travelNumber;
     private int userNumber;
     private String userName;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
     private String location;
     private String title;
@@ -33,7 +33,8 @@ public class TravelDetailResponse {
     private String periodType;
     private List<String> tags;
     private String postStatus;
-    //TODO: 조회수, 현재 모집 확정된 인원수 처리
+    //TODO: 조회수, 신청수, 관심수, 현재 모집 확정된 인원수
+    //TODO: 주최자여부, 신청가능여부
 
     @Builder
     public TravelDetailResponse(

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -27,9 +27,9 @@ public class TravelRecentDto {
     private List<String> tags;
     private int nowPerson;
     private int maxPerson;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate registerDue;
 
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
@@ -23,9 +23,9 @@ public class TravelRecommendResponse {
     private List<String> tags;
     private int nowPerson;
     private int maxPerson;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate registerDue;
 
     public TravelRecommendResponse(TravelRecommendDto dto) {

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -23,9 +23,9 @@ public class TravelSearchDto {
     private List<String> tags;
     private int nowPerson;
     private int maxPerson;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY년 MM월 dd일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate registerDue;
     private String postStatus;
 


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행 참가 신청, 수락, 거절 작업이 발생할 때 정해진 포맷의 알림을 생성해 저장한다

알림 조회 기능
사용자가 자신의 알림 목록을 조회할 때 페이징을 적용해 10개씩 알림을 보여준다
사용자가 조회가 발생하면 알림의 read 여부를 true로 변경한다

여행 알림의 경우 어떤 여행에 대한 알림인지 추가적인 정보가 필요하다
또한 향후 추가될 가능성이 있는 댓글 알림을 고려해 알림 엔티티는 Notification 추상 클래스로 구현했으며
단순 목록 조회가 주요 기능임을 고려해 JPA 단일 테이블 전략을 선택했다.



## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
