### PR TITLE
feat: 여행 조회 기능 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
@@ -13,6 +13,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
 
     int countByUserNumber(Integer userNumber);
 
+    int countByContentIdAndContentType(int travelNumber, ContentType type);
+
     // 가장 오래된 북마크 조회
     @Query("SELECT b FROM Bookmark b WHERE b.userNumber = :userNumber ORDER BY b.bookmarkDate ASC")
     List<Bookmark> findOldestByUserNumber(@Param("userNumber") Integer userNumber);

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
@@ -5,4 +5,8 @@ import swyp.swyp6_team7.enrollment.domain.Enrollment;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, EnrollmentCustomRepository {
 
+    int countByTravelNumber(int travelNumber);
+
+    boolean existsByUserNumberAndTravelNumber(int userNumber, int travelNumber);
+
 }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
@@ -29,8 +30,9 @@ public class TravelController {
     public ResponseEntity<TravelDetailResponse> create(
             @RequestBody @Validated TravelCreateRequest request, Principal principal
     ) {
+        Travel createdTravel = travelService.create(request, principal.getName());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(travelService.create(request, principal.getName()));
+                .body(travelService.getDetailsByNumber(createdTravel.getNumber()));
     }
 
     @GetMapping("/api/travel/detail/{travelNumber}")

--- a/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/TravelStatus.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TravelStatus {
     DRAFT("임시 저장"),
-    IN_PROGRESS("모집 중"),
+    IN_PROGRESS("진행중"),
     CLOSED("모집 종료"),
     DELETED("삭제");
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
@@ -1,0 +1,25 @@
+package swyp.swyp6_team7.travel.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import swyp.swyp6_team7.travel.domain.Travel;
+
+import java.util.List;
+
+@Getter
+public class TravelDetailDto {
+
+    private Travel travel;
+    private int hostNumber;
+    private String hostName;
+    private List<String> tags;
+
+    @QueryProjection
+    public TravelDetailDto(Travel travel, int hostNumber, String hostName, List<String> tags) {
+        this.travel = travel;
+        this.hostNumber = hostNumber;
+        this.hostName = hostName;
+        this.tags = tags;
+    }
+    
+}

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
@@ -12,14 +12,19 @@ public class TravelDetailDto {
     private Travel travel;
     private int hostNumber;
     private String hostName;
+    private int companionCount;
     private List<String> tags;
 
     @QueryProjection
-    public TravelDetailDto(Travel travel, int hostNumber, String hostName, List<String> tags) {
+    public TravelDetailDto(
+            Travel travel, int hostNumber, String hostName,
+            int companionCount, List<String> tags
+    ) {
         this.travel = travel;
         this.hostNumber = hostNumber;
         this.hostName = hostName;
+        this.companionCount = companionCount;
         this.tags = tags;
     }
-    
+
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
@@ -59,7 +59,7 @@ public class TravelRecommendDto {
         this.userName = userName;
         this.tags = tags.stream()
                 .limit(RECOMMEND_TAG_MAX_NUMBER).toList();
-        this.nowPerson = 1; //TODO: 현재 신청 완료 인원수
+        this.nowPerson = travel.getCompanions().size();
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
@@ -51,7 +51,7 @@ public class TravelRecommendDto {
     @QueryProjection
     public TravelRecommendDto(
             Travel travel, int userNumber, String userName,
-            List<String> tags
+            int companionCount, List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
@@ -59,7 +59,7 @@ public class TravelRecommendDto {
         this.userName = userName;
         this.tags = tags.stream()
                 .limit(RECOMMEND_TAG_MAX_NUMBER).toList();
-        this.nowPerson = travel.getCompanions().size();
+        this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -24,8 +24,8 @@ public class TravelDetailResponse {
     private String location;
     private String title;
     private String details;
-    //private int viewCount;
-    //private int nowPerson;
+    private int viewCount;
+    private int nowPerson;
     private int maxPerson;
     private String genderType;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
@@ -33,14 +33,14 @@ public class TravelDetailResponse {
     private String periodType;
     private List<String> tags;
     private String postStatus;
-    //TODO: 조회수, 신청수, 관심수, 현재 모집 확정된 인원수
+    //TODO: 신청수, 관심수
     //TODO: 주최자여부, 신청가능여부
 
     @Builder
     public TravelDetailResponse(
             int travelNumber, int userNumber, String userName,
             LocalDateTime createdAt, String location, String title,
-            String details, int maxPerson, String genderType,
+            String details, int viewCount, int nowPerson, int maxPerson, String genderType,
             LocalDate dueDate, String periodType, List<String> tags,
             String postStatus
     ) {
@@ -51,6 +51,8 @@ public class TravelDetailResponse {
         this.location = location;
         this.title = title;
         this.details = details;
+        this.viewCount = viewCount;
+        this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
         this.dueDate = dueDate;
@@ -71,6 +73,8 @@ public class TravelDetailResponse {
         this.location = travel.getLocation();
         this.title = travel.getTitle();
         this.details = travel.getDetails();
+        this.viewCount = getViewCount();
+        this.nowPerson = travel.getCompanions().size();
         this.maxPerson = travel.getMaxPerson();
         this.genderType = travel.getGenderType().toString();
         this.dueDate = travel.getDueDate();
@@ -92,6 +96,8 @@ public class TravelDetailResponse {
                 .location(travel.getLocation())
                 .title(travel.getTitle())
                 .details(travel.getDetails())
+                .viewCount(travel.getViewCount())
+                .nowPerson(travel.getCompanions().size())
                 .maxPerson(travel.getMaxPerson())
                 .genderType(travel.getGenderType().toString())
                 .dueDate(travel.getDueDate())
@@ -111,6 +117,8 @@ public class TravelDetailResponse {
                 ", location='" + location + '\'' +
                 ", title='" + title + '\'' +
                 ", details='" + details + '\'' +
+                ", viewCount=" + viewCount +
+                ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", genderType='" + genderType + '\'' +
                 ", dueDate=" + dueDate +

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,32 +18,33 @@ import java.util.List;
 public class TravelDetailResponse {
 
     private int travelNumber;
-    private int userNumber;
-    private String userName;
+    private int userNumber;     //주최자 번호
+    private String userName;    //주최자 이름
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
     private String location;
     private String title;
     private String details;
-    private int viewCount;
-    private int nowPerson;
-    private int maxPerson;
+    private int viewCount;      //조회수
+    private int enrollCount;    //신청수
+    private int bookmarkCount;  //관심수(북마크수)
+    private int nowPerson;      //현재 모집 인원
+    private int maxPerson;      //최대 모집 인원
     private String genderType;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate dueDate;
     private String periodType;
     private List<String> tags;
     private String postStatus;
-    //TODO: 신청수, 관심수
-    //TODO: 주최자여부, 신청가능여부
+    private boolean hostUser;        //주최자 여부
+    private boolean enrollAvailable; //신청 가능 여부
 
     @Builder
     public TravelDetailResponse(
-            int travelNumber, int userNumber, String userName,
-            LocalDateTime createdAt, String location, String title,
-            String details, int viewCount, int nowPerson, int maxPerson, String genderType,
-            LocalDate dueDate, String periodType, List<String> tags,
-            String postStatus
+            int travelNumber, int userNumber, String userName, LocalDateTime createdAt, String location,
+            String title, String details, int viewCount, int enrollCount, int bookmarkCount,
+            int nowPerson, int maxPerson, String genderType, LocalDate dueDate, String periodType,
+            List<String> tags, String postStatus, boolean hostUser, boolean enrollAvailable
     ) {
         this.travelNumber = travelNumber;
         this.userNumber = userNumber;
@@ -52,6 +54,8 @@ public class TravelDetailResponse {
         this.title = title;
         this.details = details;
         this.viewCount = viewCount;
+        this.enrollCount = enrollCount;
+        this.bookmarkCount = bookmarkCount;
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
@@ -59,28 +63,26 @@ public class TravelDetailResponse {
         this.periodType = periodType;
         this.tags = tags;
         this.postStatus = postStatus;
+        this.hostUser = hostUser;
+        this.enrollAvailable = enrollAvailable;
     }
 
-    @QueryProjection
-    public TravelDetailResponse(
-            Travel travel, int userNumber, String userName,
-            List<String> tags
-    ) {
-        this.travelNumber = travel.getNumber();
-        this.userNumber = userNumber;
-        this.userName = userName;
-        this.createdAt = travel.getCreatedAt();
-        this.location = travel.getLocation();
-        this.title = travel.getTitle();
-        this.details = travel.getDetails();
+    public TravelDetailResponse(TravelDetailDto travelDetail) {
+        this.travelNumber = travelDetail.getTravel().getNumber();
+        this.userNumber = travelDetail.getHostNumber();
+        this.userName = travelDetail.getHostName();
+        this.createdAt = travelDetail.getTravel().getCreatedAt();
+        this.location = travelDetail.getTravel().getLocation();
+        this.title = travelDetail.getTravel().getTitle();
+        this.details = travelDetail.getTravel().getDetails();
         this.viewCount = getViewCount();
-        this.nowPerson = travel.getCompanions().size();
-        this.maxPerson = travel.getMaxPerson();
-        this.genderType = travel.getGenderType().toString();
-        this.dueDate = travel.getDueDate();
-        this.periodType = travel.getPeriodType().toString();
-        this.tags = tags;
-        this.postStatus = travel.getStatus().toString();
+        this.nowPerson = travelDetail.getTravel().getCompanions().size();
+        this.maxPerson = travelDetail.getTravel().getMaxPerson();
+        this.genderType = travelDetail.getTravel().getGenderType().toString();
+        this.dueDate = travelDetail.getTravel().getDueDate();
+        this.periodType = travelDetail.getTravel().getPeriodType().toString();
+        this.tags = travelDetail.getTags();
+        this.postStatus = travelDetail.getTravel().getStatus().toString();
     }
 
     public static TravelDetailResponse from(
@@ -118,6 +120,8 @@ public class TravelDetailResponse {
                 ", title='" + title + '\'' +
                 ", details='" + details + '\'' +
                 ", viewCount=" + viewCount +
+                ", enrollCount=" + enrollCount +
+                ", bookmarkCount=" + bookmarkCount +
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", genderType='" + genderType + '\'' +
@@ -125,6 +129,8 @@ public class TravelDetailResponse {
                 ", periodType='" + periodType + '\'' +
                 ", tags=" + tags +
                 ", postStatus='" + postStatus + '\'' +
+                ", hostUser=" + hostUser +
+                ", enrollAvailable=" + enrollAvailable +
                 '}';
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -1,12 +1,10 @@
 package swyp.swyp6_team7.travel.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 
 import java.time.LocalDate;
@@ -36,7 +34,7 @@ public class TravelDetailResponse {
     private String periodType;
     private List<String> tags;
     private String postStatus;
-    private boolean hostUser;        //주최자 여부
+    private boolean hostUserCheck;        //주최자 여부
     private boolean enrollAvailable; //신청 가능 여부
 
     @Builder
@@ -44,7 +42,7 @@ public class TravelDetailResponse {
             int travelNumber, int userNumber, String userName, LocalDateTime createdAt, String location,
             String title, String details, int viewCount, int enrollCount, int bookmarkCount,
             int nowPerson, int maxPerson, String genderType, LocalDate dueDate, String periodType,
-            List<String> tags, String postStatus, boolean hostUser, boolean enrollAvailable
+            List<String> tags, String postStatus, boolean hostUserCheck, boolean enrollAvailable
     ) {
         this.travelNumber = travelNumber;
         this.userNumber = userNumber;
@@ -63,11 +61,14 @@ public class TravelDetailResponse {
         this.periodType = periodType;
         this.tags = tags;
         this.postStatus = postStatus;
-        this.hostUser = hostUser;
+        this.hostUserCheck = hostUserCheck;
         this.enrollAvailable = enrollAvailable;
     }
 
-    public TravelDetailResponse(TravelDetailDto travelDetail) {
+    public TravelDetailResponse(
+            TravelDetailDto travelDetail,
+            int enrollCount, int bookmarkCount
+    ) {
         this.travelNumber = travelDetail.getTravel().getNumber();
         this.userNumber = travelDetail.getHostNumber();
         this.userName = travelDetail.getHostName();
@@ -76,7 +77,9 @@ public class TravelDetailResponse {
         this.title = travelDetail.getTravel().getTitle();
         this.details = travelDetail.getTravel().getDetails();
         this.viewCount = getViewCount();
-        this.nowPerson = travelDetail.getTravel().getCompanions().size();
+        this.enrollCount = enrollCount;
+        this.bookmarkCount = bookmarkCount;
+        this.nowPerson = travelDetail.getCompanionCount();
         this.maxPerson = travelDetail.getTravel().getMaxPerson();
         this.genderType = travelDetail.getTravel().getGenderType().toString();
         this.dueDate = travelDetail.getTravel().getDueDate();
@@ -85,28 +88,17 @@ public class TravelDetailResponse {
         this.postStatus = travelDetail.getTravel().getStatus().toString();
     }
 
-    public static TravelDetailResponse from(
-            Travel travel,
-            List<String> tags,
-            int userNumber, String userName
-    ) {
-        return TravelDetailResponse.builder()
-                .travelNumber(travel.getNumber())
-                .userNumber(userNumber)
-                .userName(userName)
-                .createdAt(travel.getCreatedAt())
-                .location(travel.getLocation())
-                .title(travel.getTitle())
-                .details(travel.getDetails())
-                .viewCount(travel.getViewCount())
-                .nowPerson(travel.getCompanions().size())
-                .maxPerson(travel.getMaxPerson())
-                .genderType(travel.getGenderType().toString())
-                .dueDate(travel.getDueDate())
-                .periodType(travel.getPeriodType().toString())
-                .tags(tags)
-                .postStatus(travel.getStatus().toString())
-                .build();
+
+    public void setHostUserCheckTrue() {
+        this.hostUserCheck = true;
+    }
+
+    public void setEnrollAvailable(boolean existEnrollment) {
+        if (existEnrollment) {
+            this.enrollAvailable = false;
+        } else {
+            this.enrollAvailable = true;
+        }
     }
 
     @Override
@@ -129,7 +121,7 @@ public class TravelDetailResponse {
                 ", periodType='" + periodType + '\'' +
                 ", tags=" + tags +
                 ", postStatus='" + postStatus + '\'' +
-                ", hostUser=" + hostUser +
+                ", hostUserCheck=" + hostUserCheck +
                 ", enrollAvailable=" + enrollAvailable +
                 '}';
     }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -60,7 +60,7 @@ public class TravelRecentDto {
         this.userNumber = userNumber;
         this.userName = userName;
         this.tags = tags.stream().limit(TAG_MAX_NUMBER).toList();
-        this.nowPerson = 1; //todo
+        this.nowPerson = travel.getCompanions().size();
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -53,14 +53,14 @@ public class TravelRecentDto {
     @QueryProjection
     public TravelRecentDto(
             Travel travel, int userNumber, String userName,
-            List<String> tags
+            int companionCount, List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
         this.userNumber = userNumber;
         this.userName = userName;
         this.tags = tags.stream().limit(TAG_MAX_NUMBER).toList();
-        this.nowPerson = travel.getCompanions().size();
+        this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -50,14 +50,14 @@ public class TravelSearchDto {
     @QueryProjection
     public TravelSearchDto(
             Travel travel, int userNumber, String userName,
-            List<String> tags
+            int companionCount, List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
         this.userNumber = userNumber;
         this.userName = userName;
         this.tags = tags;
-        this.nowPerson = travel.getCompanions().size();
+        this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -57,7 +57,7 @@ public class TravelSearchDto {
         this.userNumber = userNumber;
         this.userName = userName;
         this.tags = tags;
-        this.nowPerson = 1; //TODO
+        this.nowPerson = travel.getCompanions().size();
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -2,10 +2,10 @@ package swyp.swyp6_team7.travel.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
-import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
-import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 
 import java.util.List;
@@ -18,6 +18,6 @@ public interface TravelCustomRepository {
 
     Page<TravelSearchDto> search(TravelSearchCondition condition);
 
-    TravelDetailResponse getDetailsByNumber(int travelNumber);
+    TravelDetailDto getDetailsByNumber(int travelNumber);
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -100,6 +100,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 travel,
                                 users.userNumber,
                                 users.userName,
+                                travel.companions.size(),
                                 list(tag.name)))
                 );
 
@@ -142,7 +143,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
         List<Integer> travels = tuples.stream()
                 .map(t -> t.get(travel.number))
                 .toList();
-        log.info("travelsNumber: " + travels);
+        //log.info("travelsNumber: " + travels);
 
         Map<Integer, Integer> travelMap = new HashMap<>();
         for (Tuple tuple : tuples) {
@@ -164,6 +165,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 travel,
                                 users.userNumber,
                                 users.userName,
+                                travel.companions.size(),
                                 list(tag.name)
                                 ))
                 );
@@ -212,6 +214,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 travel,
                                 users.userNumber,
                                 users.userName,
+                                travel.companions.size(),
                                 list(tag.name)))
                 );
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -65,6 +65,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         travel,
                         users.userNumber,
                         users.userName,
+                        travel.companions.size(),
                         list(tag.name)
                 ))).get(travelNumber);
     }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -2,7 +2,10 @@ package swyp.swyp6_team7.travel.repository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -18,9 +21,12 @@ import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.QTravel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.dto.QTravelDetailDto;
+import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
-import swyp.swyp6_team7.travel.dto.response.*;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.util.TravelSearchConstant;
 
 import java.util.HashMap;
@@ -47,7 +53,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
 
     @Override
-    public TravelDetailResponse getDetailsByNumber(int travelNumber) {
+    public TravelDetailDto getDetailsByNumber(int travelNumber) {
         return queryFactory
                 .select(travel)
                 .from(travel)
@@ -55,7 +61,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(travel.number.eq(travelNumber))
-                .transform(groupBy(travel.number).as(new QTravelDetailResponse(
+                .transform(groupBy(travel.number).as(new QTravelDetailDto(
                         travel,
                         users.userNumber,
                         users.userName,

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -11,6 +11,7 @@ import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
@@ -53,7 +54,13 @@ public class TravelService {
             throw new IllegalArgumentException("Deleted Travel.");
         }
 
-        return travelRepository.getDetailsByNumber(travelNumber);
+        TravelDetailDto travelDetail = travelRepository.getDetailsByNumber(travelNumber);
+        //enrollment 개수
+        //bookmark 개수
+        //주최자여부
+        //신청가능 여부
+
+        return new TravelDetailResponse(travelDetail);
     }
 
     @Transactional

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -6,6 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.auth.jwt.JwtProvider;
+import swyp.swyp6_team7.bookmark.entity.ContentType;
+import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
+import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.tag.service.TravelTagService;
@@ -28,11 +32,13 @@ import java.util.List;
 public class TravelService {
 
     private final TravelRepository travelRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final TravelTagService travelTagService;
     private final MemberService memberService;
 
     @Transactional
-    public TravelDetailResponse create(TravelCreateRequest request, String email) {
+    public Travel create(TravelCreateRequest request, String email) {
 
         Users user = memberService.findByEmail(email);
 
@@ -41,7 +47,7 @@ public class TravelService {
                 .map(tag -> tag.getName())
                 .toList();
 
-        return TravelDetailResponse.from(savedTravel, tags, user.getUserNumber(), user.getUserName());
+        return savedTravel;
     }
 
     public TravelDetailResponse getDetailsByNumber(int travelNumber) {
@@ -56,11 +62,24 @@ public class TravelService {
 
         TravelDetailDto travelDetail = travelRepository.getDetailsByNumber(travelNumber);
         //enrollment 개수
+        int enrollmentCount = enrollmentRepository.countByTravelNumber(travelNumber);
+        log.info("enrollmentCount: " + enrollmentCount);
         //bookmark 개수
-        //주최자여부
-        //신청가능 여부
+        int bookmarkCount = bookmarkRepository.countByContentIdAndContentType(travelNumber, ContentType.TRAVEL);
+        log.info("bookmarkCount: " + bookmarkCount);
+        TravelDetailResponse detailResponse = new TravelDetailResponse(travelDetail, enrollmentCount, bookmarkCount);
 
-        return new TravelDetailResponse(travelDetail);
+        String requestUserName = SecurityContextHolder.getContext().getAuthentication().getName();
+        int requestUserNumber = memberService.findByEmail(requestUserName).getUserNumber();
+        if (travelDetail.getHostNumber() == requestUserNumber) {
+            detailResponse.setHostUserCheckTrue();
+        } else {
+            boolean existEnrollment = enrollmentRepository
+                    .existsByUserNumberAndTravelNumber(requestUserNumber, travelNumber);
+            detailResponse.setEnrollAvailable(existEnrollment);
+        }
+
+        return detailResponse;
     }
 
     @Transactional

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -45,6 +46,8 @@ class TravelControllerTest {
     protected ObjectMapper objectMapper;
     @Autowired
     private WebApplicationContext context;
+    @Autowired
+    private UserDetailsService userDetailsService;
 
     @Autowired
     TravelRepository travelRepository;
@@ -75,11 +78,15 @@ class TravelControllerTest {
                 .userStatus(UserStatus.ABLE)
                 .build());
 
+        var userDetails = userDetailsService.loadUserByUsername(user.getUserEmail());
         SecurityContext context = SecurityContextHolder.getContext();
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(user, user.getUserPw(), user.getAuthorities());
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
 
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(user, user.getUserPw(), user.getAuthorities()));
+//        SecurityContext context = SecurityContextHolder.getContext();
+//        UsernamePasswordAuthenticationToken authenticationToken =
+//                new UsernamePasswordAuthenticationToken(user, user.getUserPw(), user.getAuthorities());
+//
+//        context.setAuthentication(new UsernamePasswordAuthenticationToken(user, user.getUserPw(), user.getAuthorities()));
     }
 
     @DisplayName("create: 사용자는 여행 콘텐츠를 생성할 수 있다")
@@ -125,8 +132,7 @@ class TravelControllerTest {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value(savedTravel.getTitle()))
-                .andExpect(jsonPath("$.userNumber").value(user.getUserNumber()))
-                .andExpect(jsonPath("$.userName").value(user.getUserName()));
+                .andExpect(jsonPath("$.userNumber").value(user.getUserNumber()));
     }
 
     @DisplayName("getDetailsByNumber: 작성자가 아닌 경우 Draft 상태의 콘텐츠 단건 조회를 하면 예외가 발생")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -22,10 +22,10 @@ import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
-import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
-import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
-import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 
 import java.time.LocalDate;
@@ -91,13 +91,13 @@ class TravelCustomRepositoryImplTest {
         travelTagRepository.save(TravelTag.of(travel, tag2));
 
         // when
-        TravelDetailResponse details = travelRepository.getDetailsByNumber(travel.getNumber());
+        TravelDetailDto details = travelRepository.getDetailsByNumber(travel.getNumber());
 
         // then
         System.out.println(details.toString());
-        assertThat(details.getTitle()).isEqualTo("추가 테스트 데이터1");
-        assertThat(details.getUserNumber()).isEqualTo(user.getUserNumber());
-        assertThat(details.getUserName()).isEqualTo("모잉");
+        assertThat(details.getTravel().getTitle()).isEqualTo("추가 테스트 데이터1");
+        assertThat(details.getHostNumber()).isEqualTo(user.getUserNumber());
+        assertThat(details.getHostName()).isEqualTo("모잉");
         assertThat(details.getTags().size()).isEqualTo(2);
     }
 

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelListServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelListServiceTest.java
@@ -1,3 +1,5 @@
+package swyp.swyp6_team7.travel.service;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -129,7 +131,7 @@ class TravelListServiceTest {
         assertEquals(List.of("tag2"), travel2Dto.getTags());
 
         verify(travelRepository, times(1)).findByUserNumber(userNumber);
-        verify(userRepository, times(1)).findByUserNumber(userNumber);
+        //verify(userRepository, times(1)).findByUserNumber(userNumber);
         verify(bookmarkRepository, times(2)).existsByUserNumberAndContentIdAndContentType(eq(userNumber), anyInt(), any());
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -10,6 +10,7 @@ import swyp.swyp6_team7.member.entity.Gender;
 import swyp.swyp6_team7.member.entity.UserStatus;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 
@@ -53,12 +54,11 @@ class TravelServiceTest {
                 .build();
 
         // when
-        TravelDetailResponse detailTravel = travelService.create(request, "test@naver.com");
+        Travel createdTravel = travelService.create(request, "test@naver.com");
 
         // then
-        assertThat(detailTravel.getTitle()).isEqualTo(request.getTitle());
-        assertThat(detailTravel.getUserNumber()).isEqualTo(user.getUserNumber());
-        assertThat(detailTravel.getUserName()).isEqualTo(user.getUserName());
+        assertThat(createdTravel.getTitle()).isEqualTo(request.getTitle());
+        assertThat(createdTravel.getUserNumber()).isEqualTo(user.getUserNumber());
     }
 
 }


### PR DESCRIPTION
## 🔗 Issue Number
feat: 여행 조회 관련 기능에 신청/모집 적용 #33

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행 콘텐츠 상세 조회 정보에 신청수, 관심수, 주최여부, 신청 가능 여부를 추가함
querydsl에서 여행 및 주최 정보를 가져올 때만 사용할 목적으로 TravelDetailDto를 추가함
기존의 TravelDetailResponse는 TravelDetailDto에 신청수, 관심수, 주최여부, 신청 가능 여부가 추가되는 형태

여행 목록 조회 계열 기능에 현재 모집완료된 인원 정보가 제대로 들어가도록 더미 데이터를 삭제하고 수정함
querydsl에서 Travel companions 리스트의 size를 함께 가져오도록 DTO를 수정함


## 🔖 리뷰 요구사항(선택)
.

## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
