### PR TITLE
feat: Notification 목록 조회 정렬 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
+++ b/src/main/java/swyp/swyp6_team7/Swyp6Team7Application.java
@@ -12,7 +12,6 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 @EnableJpaAuditing
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @EnableAsync
-@EnableJpaRepositories(basePackages = "swyp.swyp6_team7.repository")
 @SpringBootApplication
 public class Swyp6Team7Application {
 

--- a/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
+++ b/src/main/java/swyp/swyp6_team7/notification/repository/NotificationRepository.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> getNotificationsByReceiverNumberOrderByCreatedAtDesc(int userNumber);
-
-    Page<Notification> getNotificationsByReceiverNumberOrderByCreatedAtDesc(int userNumber, Pageable pageable);
+    Page<Notification> getNotificationsByReceiverNumberOrderByIsReadAscCreatedAtDesc(int userNumber, Pageable pageable);
 
 }

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -58,7 +58,7 @@ public class NotificationService {
         Users user = memberService.findByEmail(userName);
 
         Page<Notification> notifications = notificationRepository
-                .getNotificationsByReceiverNumberOrderByCreatedAtDesc(user.getUserNumber(), pageRequest);
+                .getNotificationsByReceiverNumberOrderByIsReadAscCreatedAtDesc(user.getUserNumber(), pageRequest);
 
         return notifications.map(notification -> makeDto(notification));
     }

--- a/src/test/java/swyp/swyp6_team7/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,96 @@
+package swyp.swyp6_team7.notification.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import swyp.swyp6_team7.config.DataConfig;
+import swyp.swyp6_team7.notification.entity.Notification;
+import swyp.swyp6_team7.notification.entity.TravelNotification;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@DataJpaTest
+@Import(DataConfig.class)
+public class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @MockBean
+    private DateTimeProvider dateTimeProvider;
+    @SpyBean
+    private AuditingHandler handler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        handler.setDateTimeProvider(dateTimeProvider);
+    }
+
+
+    @DisplayName("getNotifications: isRead가 false인 알림이 우선정렬된다")
+    @Test
+    public void getNotificationsByReceiverNumber() {
+        // given
+        LocalDateTime testTime1 = LocalDateTime.of(2024, 9, 25, 10, 0);
+        when(dateTimeProvider.getNow()).thenReturn(Optional.of(testTime1));
+
+        Notification readNotification1 = notificationRepository.save(TravelNotification.builder()
+                .travelNumber(1)
+                .receiverNumber(1)
+                .isRead(true)
+                .build());
+
+        Notification unreadNotification1 = notificationRepository.save(TravelNotification.builder()
+                .travelNumber(1)
+                .receiverNumber(1)
+                .isRead(false)
+                .build());
+
+        LocalDateTime testTime2 = LocalDateTime.of(2024, 9, 30, 10, 0);
+        when(dateTimeProvider.getNow()).thenReturn(Optional.of(testTime2));
+
+        Notification readNotification2 = notificationRepository.save(TravelNotification.builder()
+                .travelNumber(1)
+                .receiverNumber(1)
+                .isRead(true)
+                .build());
+
+        Notification unreadNotification2 = notificationRepository.save(TravelNotification.builder()
+                .travelNumber(1)
+                .receiverNumber(1)
+                .isRead(false)
+                .build());
+
+        PageRequest pageRequest = PageRequest.of(0, 5);
+
+        // when
+        Page<Notification> notifications = notificationRepository
+                .getNotificationsByReceiverNumberOrderByIsReadAscCreatedAtDesc(1, pageRequest);
+
+        // then
+        for (Notification notification : notifications.getContent()) {
+            System.out.println(notification.toString());
+        }
+        assertThat(notifications.getTotalElements()).isEqualTo(4);
+        assertThat(notifications.getContent().get(0)).isEqualTo(unreadNotification2);
+        assertThat(notifications.getContent().get(1)).isEqualTo(unreadNotification1);
+        assertThat(notifications.getContent().get(2)).isEqualTo(readNotification2);
+        assertThat(notifications.getContent().get(3)).isEqualTo(readNotification1);
+    }
+
+}


### PR DESCRIPTION
## 🔗 Issue Number

> 연관된 이슈 번호를 기입해주세요.   
> ex) #이슈번호, #이슈번호

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
Notification 목록 조회에 사용하는 Repository 메서드를 수정함
isRead 값이 false인 Notification이 앞쪽 페이지에 위치하도록 Order by 조건을 추가.
isRead에 대해 Asc, createdAt에 대해 desc를 수행함
`Page<Notification> getNotificationsByReceiverNumberOrderByIsReadAscCreatedAtDesc(int userNumber, Pageable pageable);`


## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
