### PR TITLE
feat: 여행 참가 신청 기능에서 신청자도 알림을 받을 수 있도록 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/companion/domain/Companion.java
+++ b/src/main/java/swyp/swyp6_team7/companion/domain/Companion.java
@@ -9,9 +9,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import swyp.swyp6_team7.travel.domain.Travel;
 
 @Getter
-@Table(name = "travel_companion", uniqueConstraints = {
+@Table(name = "companions", uniqueConstraints = {
         @UniqueConstraint(
-                name = "travel_companion_unique", columnNames = {"travel_number", "user_number"}
+                name = "companions_unique", columnNames = {"travel_number", "user_number"}
         )}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,6 +21,7 @@ public class Companion {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "companion_number")
     private Long number;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/swyp/swyp6_team7/enrollment/domain/Enrollment.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/domain/Enrollment.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
-@Table(name = "travel_enrollment")
+@Table(name = "enrollments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Entity
@@ -20,20 +20,20 @@ public class Enrollment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "enrollment_number")
-    private long number;
+    private Long number;
 
     @Column(name = "user_number", nullable = false)
-    private int userNumber;
+    private Integer userNumber;
 
     @Column(name = "travel_number", nullable = false)
-    private int travelNumber;
+    private Integer travelNumber;
 
     @CreatedDate
     @Column(name = "enrollment_datetime", nullable = false)
     private LocalDateTime createdAt;
 
     @Lob
-    @Column(name = "enrollment_message")
+    @Column(name = "enrollment_message", length = 1000)
     private String message;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -48,7 +48,8 @@ public class EnrollmentService {
         enrollmentRepository.save(created);
 
         //알림
-        notificationService.createEnrollNotificaton(targetTravel, user);
+        notificationService.createEnrollNotificaton(targetTravel); //주최자
+        //TODO: 신청자알림
     }
 
     @Transactional

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -48,8 +48,8 @@ public class EnrollmentService {
         enrollmentRepository.save(created);
 
         //알림
-        notificationService.createEnrollNotificaton(targetTravel); //주최자
-        //TODO: 신청자알림
+        notificationService.createEnrollNotificatonToHost(targetTravel); //주최자
+        notificationService.createEnrollNotification(targetTravel, user); //신청자
     }
 
     @Transactional

--- a/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
@@ -10,16 +10,17 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
-@Table(name = "notification")
+@Table(name = "notifications")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "notification_type")
+@DiscriminatorColumn(name = "dtype", discriminatorType = DiscriminatorType.STRING, length = 20)
 @Entity
 public abstract class Notification {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_number")
     private Long number;
 
     @CreatedDate
@@ -29,10 +30,10 @@ public abstract class Notification {
     @Column(name = "notification_receiver_number", nullable = false)
     private Integer receiverNumber;
 
-    @Column(name = "notification_title")
+    @Column(name = "notification_title", length = 20)
     private String title;
 
-    @Column(name = "notification_content")
+    @Column(name = "notification_content", length = 100)
     private String content;
 
     @Column(name = "notification_read", nullable = false)

--- a/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
@@ -7,10 +7,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationMessageType {
 
-    TRAVEL_ENROLL("여행 신청 알림"),
-    TRAVEL_ACCEPT("참가 확정 알림"),
-    TRAVEL_REJECT("참가 거절 알림");
+    TRAVEL_ENROLL_HOST("여행 신청 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("[%s]에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.", travelTitle);
+        }
+    },
+    TRAVEL_ENROLL("참가 신청 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("[%s]에 참가 신청이 완료되었어요. 주최자가 참가를 확정하면 알려드릴게요.", travelTitle);
+        }
+    },
+
+    TRAVEL_ACCEPT("참가 확정 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("[%s]에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.", travelTitle);
+        }
+    },
+
+    TRAVEL_REJECT("참가 거절 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("[%s]에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?", travelTitle);
+        }
+    };
 
     private final String title;
-
+    public abstract String getContent(String travelTitle);
 }

--- a/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
@@ -5,11 +5,11 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum NotificationType {
+public enum NotificationMessageType {
 
-    TRAVEL_ENROLL("여행 참가 신청"),
-    TRAVEL_ACCEPT("여행 참가 신청"),
-    TRAVEL_REJECT("여행 참가 신청");
+    TRAVEL_ENROLL("여행 신청 알림"),
+    TRAVEL_ACCEPT("참가 확정 알림"),
+    TRAVEL_REJECT("참가 거절 알림");
 
     private final String title;
 

--- a/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
@@ -20,7 +20,7 @@ public class TravelNotification extends Notification {
     @Column(name = "travel_number", nullable = false)
     private Integer travelNumber;
 
-    @Column(name = "travel_title")
+    @Column(name = "travel_title", length = 20)
     private String travelTitle;
 
     @Column(name = "travel_due_date")

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -32,8 +32,8 @@ public class NotificationService {
 
 
     @Async
-    public void createEnrollNotificaton(Travel targetTravel, Users user) {
-        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel, user);
+    public void createEnrollNotificaton(Travel targetTravel) {
+        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel);
         newNotification = notificationRepository.save(newNotification);
         log.info("[알림] 참가신청 =" + newNotification.toString());
     }

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -19,8 +19,6 @@ import swyp.swyp6_team7.notification.repository.NotificationRepository;
 import swyp.swyp6_team7.notification.util.NotificationMaker;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.util.List;
-
 @Slf4j
 @Transactional
 @RequiredArgsConstructor
@@ -32,24 +30,31 @@ public class NotificationService {
 
 
     @Async
-    public void createEnrollNotificaton(Travel targetTravel) {
-        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel);
+    public void createEnrollNotificatonToHost(Travel targetTravel) {
+        Notification newNotification = NotificationMaker.travelEnrollmentMessageToHost(targetTravel);
         newNotification = notificationRepository.save(newNotification);
-        log.info("[알림] 참가신청 =" + newNotification.toString());
+        log.info("[알림]여행신청 =" + newNotification.toString());
+    }
+
+    @Async
+    public void createEnrollNotification(Travel targetTravel, Users user) {
+        Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel, user);
+        newNotification = notificationRepository.save(newNotification);
+        log.info("[알림]참가신청 =" + newNotification.toString());
     }
 
     @Async
     public void createAcceptNotification(Travel targetTravel, Enrollment enrollment) {
         Notification newNotification = NotificationMaker.travelAcceptMessage(targetTravel, enrollment);
         newNotification = notificationRepository.save(newNotification);
-        log.info("[알림] 신청수락 = " + newNotification.toString());
+        log.info("[알림]참가확정 = " + newNotification.toString());
     }
 
     @Async
     public void createRejectNotification(Travel targetTravel, Enrollment enrollment) {
         Notification newNotification = NotificationMaker.travelRejectMessage(targetTravel, enrollment);
         newNotification = notificationRepository.save(newNotification);
-        log.info("[알림] 신청거절 = " + newNotification.toString());
+        log.info("[알림]참가거절 = " + newNotification.toString());
     }
 
 

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -1,6 +1,7 @@
 package swyp.swyp6_team7.notification.util;
 
 import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.notification.entity.Notification;
 import swyp.swyp6_team7.notification.entity.NotificationMessageType;
 import swyp.swyp6_team7.notification.entity.TravelNotification;
@@ -8,11 +9,23 @@ import swyp.swyp6_team7.travel.domain.Travel;
 
 public class NotificationMaker {
 
-    public static Notification travelEnrollmentMessage(Travel targetTravel) {
+    public static Notification travelEnrollmentMessageToHost(Travel targetTravel) {
         return TravelNotification.builder()
                 .receiverNumber(targetTravel.getUserNumber())
+                .title(NotificationMessageType.TRAVEL_ENROLL_HOST.getTitle())
+                .content(NotificationMessageType.TRAVEL_ENROLL_HOST.getContent(targetTravel.getTitle()))
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelEnrollmentMessage(Travel targetTravel, Users users) {
+        return TravelNotification.builder()
+                .receiverNumber(users.getUserNumber())
                 .title(NotificationMessageType.TRAVEL_ENROLL.getTitle())
-                .content(targetTravel.getTitle() + "에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.")
+                .content(NotificationMessageType.TRAVEL_ENROLL.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
@@ -24,7 +37,7 @@ public class NotificationMaker {
         return TravelNotification.builder()
                 .receiverNumber(enrollment.getUserNumber())
                 .title(NotificationMessageType.TRAVEL_ACCEPT.getTitle())
-                .content(targetTravel.getTitle() + "에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.")
+                .content(NotificationMessageType.TRAVEL_ACCEPT.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
@@ -36,7 +49,7 @@ public class NotificationMaker {
         return TravelNotification.builder()
                 .receiverNumber(enrollment.getUserNumber())
                 .title(NotificationMessageType.TRAVEL_REJECT.getTitle())
-                .content(targetTravel.getTitle() + "에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?")
+                .content(NotificationMessageType.TRAVEL_REJECT.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -1,19 +1,18 @@
 package swyp.swyp6_team7.notification.util;
 
 import swyp.swyp6_team7.enrollment.domain.Enrollment;
-import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.notification.entity.Notification;
-import swyp.swyp6_team7.notification.entity.NotificationType;
+import swyp.swyp6_team7.notification.entity.NotificationMessageType;
 import swyp.swyp6_team7.notification.entity.TravelNotification;
 import swyp.swyp6_team7.travel.domain.Travel;
 
 public class NotificationMaker {
 
-    public static Notification travelEnrollmentMessage(Travel targetTravel, Users user) {
+    public static Notification travelEnrollmentMessage(Travel targetTravel) {
         return TravelNotification.builder()
                 .receiverNumber(targetTravel.getUserNumber())
-                .title(NotificationType.TRAVEL_ENROLL.getTitle())
-                .content(user.getUserName() + "님이 참가를 희망했어요.\n수락하시려면 눌러주세요.")
+                .title(NotificationMessageType.TRAVEL_ENROLL.getTitle())
+                .content(targetTravel.getTitle() + "에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.")
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
@@ -24,8 +23,8 @@ public class NotificationMaker {
     public static Notification travelAcceptMessage(Travel targetTravel, Enrollment enrollment) {
         return TravelNotification.builder()
                 .receiverNumber(enrollment.getUserNumber())
-                .title(NotificationType.TRAVEL_ACCEPT.getTitle())
-                .content("여행 신청이 수락되었어요.")
+                .title(NotificationMessageType.TRAVEL_ACCEPT.getTitle())
+                .content(targetTravel.getTitle() + "에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.")
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
@@ -36,8 +35,8 @@ public class NotificationMaker {
     public static Notification travelRejectMessage(Travel targetTravel, Enrollment enrollment) {
         return TravelNotification.builder()
                 .receiverNumber(enrollment.getUserNumber())
-                .title(NotificationType.TRAVEL_REJECT.getTitle())
-                .content("여행 신청이 거절되었어요.\n다른 여행을 찾아보세요!")
+                .title(NotificationMessageType.TRAVEL_REJECT.getTitle())
+                .content(targetTravel.getTitle() + "에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?")
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,18 +2,18 @@ spring:
   profiles:
     active: local-db
 ---
-spring:
-  datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/moing
-    username: root
-    password: 2478
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      jakarta.persistence.jdbc.url: jdbc:mariadb://localhost:3306/moing
-      hibernate:
-        dialect: org.hibernate.dialect.MariaDBDialect
-    show-sql: true
+#spring:
+#  datasource:
+#    driver-class-name: org.mariadb.jdbc.Driver
+#    url: jdbc:mariadb://localhost:3306/moing
+#    username: root
+#    password: 2478
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    properties:
+#      jakarta.persistence.jdbc.url: jdbc:mariadb://localhost:3306/moing
+#      hibernate:
+#        dialect: org.hibernate.dialect.MariaDBDialect
+#    show-sql: true


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
- 여행 참가 신청 기능에서 참가 신청이 발생할 때 주최자, 신청자 모두에게 알림이 생성되도록 EnrollmentService를 수정함
- NotificationService 메서드 추가
    - createEnrollNotificatonToHost()는 주최자가 수신하는 알림 생성
    - createEnrollNotification()는 신청자가 수신하는 알림 생성
- NotificationMessageType Enum 클래스에서 notification의 content를 생성하도록 수정
    - `public abstract String getContent(String travelTitle)` 추가
    - 각 Enum 타입에 따라 getContent 함수를 실행해 content를 가져올 수 있다

## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
