### PR TITLE
fix: enrollment 목록 조회 로직 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package swyp.swyp6_team7.enrollment.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 import swyp.swyp6_team7.enrollment.domain.QEnrollment;
 import swyp.swyp6_team7.enrollment.dto.EnrollmentResponse;
 import swyp.swyp6_team7.enrollment.dto.QEnrollmentResponse;
@@ -11,11 +12,9 @@ import swyp.swyp6_team7.travel.domain.QTravel;
 
 import java.util.List;
 
-import static swyp.swyp6_team7.travel.domain.QTravel.travel;
-
 
 @Repository
-public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepository{
+public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -41,14 +40,17 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
                 ))
                 .from(enrollment)
                 .leftJoin(users).on(enrollment.userNumber.eq(users.userNumber))
-                .where(enrollment.travelNumber.eq(travelNumber))
+                .where(
+                        enrollment.travelNumber.eq(travelNumber),
+                        enrollment.status.eq(EnrollmentStatus.PENDING))
                 .orderBy(enrollment.createdAt.desc())
                 .fetch();
     }
+
     @Override
     public List<Tuple> findEnrollmentsByUserNumber(int userNumber) {
         return queryFactory
-                .select(enrollment.number, travel.number,enrollment.status)
+                .select(enrollment.number, travel.number, enrollment.status)
                 .from(enrollment)
                 .leftJoin(users).on(enrollment.userNumber.eq(users.userNumber))
                 .leftJoin(travel).on(enrollment.travelNumber.eq(travel.number))

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
@@ -2,10 +2,13 @@ package swyp.swyp6_team7.enrollment.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, EnrollmentCustomRepository {
 
     int countByTravelNumber(int travelNumber);
+
+    long countByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status);
 
     Enrollment findOneByUserNumberAndTravelNumber(int userNumber, int travelNumber);
 

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.companion.domain.Companion;
 import swyp.swyp6_team7.companion.repository.CompanionRepository;
 import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 import swyp.swyp6_team7.enrollment.dto.EnrollmentCreateRequest;
 import swyp.swyp6_team7.enrollment.dto.EnrollmentResponse;
 import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
@@ -68,6 +69,10 @@ public class EnrollmentService {
 
         List<EnrollmentResponse> enrollments = enrollmentRepository.findEnrollmentsByTravelNumber(travelNumber);
         return TravelEnrollmentsResponse.from(enrollments);
+    }
+
+    public long getPendingEnrollmentsCountByTravelNumber(int travelNumber) {
+        return enrollmentRepository.countByTravelNumberAndStatus(travelNumber, EnrollmentStatus.PENDING);
     }
 
     @Transactional

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelEnrollmentController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelEnrollmentController.java
@@ -34,6 +34,12 @@ public class TravelEnrollmentController {
                 .body(response);
     }
 
+    @GetMapping("/api/travel/{travelNumber}/enrollmentCount")
+    public ResponseEntity getEnrollmentsCount(@PathVariable("travelNumber") int travelNumber) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(enrollmentService.getPendingEnrollmentsCountByTravelNumber(travelNumber));
+    }
+
     @PutMapping("/api/travel/{travelNumber}/enrollments/last-viewed")
     public ResponseEntity updateEnrollmentsLastViewedTime(
             @PathVariable("travelNumber") int travelNumber,


### PR DESCRIPTION
## 🔗 Issue Number

.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
- 특정 여행에 대한 enrollment 목록 조회 로직 수정
  - 기존: status에 상관없이 찾은 enrollment를 전달
  - 현재: status가 PENDING(대기) 상태인 enrollment만 전달
- 특정 여행에 대한 PENDING 상태의 신청서 개수를 전달하는 GET 요청 추가
  - `/api/travel/{travelNumber}/enrollmentCount`


## 🔖 리뷰 요구사항(선택)

.


## ✅ PR Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
