### PR TITLE
feat: 여행콘텐츠 댓글 생성 알림

### DIFF
--- a/src/main/java/swyp/swyp6_team7/comment/controller/CommentController.java
+++ b/src/main/java/swyp/swyp6_team7/comment/controller/CommentController.java
@@ -32,8 +32,8 @@ public class CommentController {
     public ResponseEntity<CommentDetailResponseDto> create(
             @RequestBody CommentCreateRequestDto request,
             Principal principal,
-            @PathVariable String relatedType,
-            @PathVariable int relatedNumber
+            @PathVariable(name = "relatedType") String relatedType,
+            @PathVariable(name = "relatedNumber") int relatedNumber
     ) {
         //user number 가져오기
         String userEmail = principal.getName();

--- a/src/main/java/swyp/swyp6_team7/comment/service/CommentService.java
+++ b/src/main/java/swyp/swyp6_team7/comment/service/CommentService.java
@@ -14,10 +14,10 @@ import swyp.swyp6_team7.comment.repository.CommentRepository;
 import swyp.swyp6_team7.image.s3.S3Uploader;
 import swyp.swyp6_team7.likes.dto.response.CommentLikeReadResponseDto;
 import swyp.swyp6_team7.likes.repository.CommentLikeRepository;
-import swyp.swyp6_team7.likes.service.CommentLikeService;
 import swyp.swyp6_team7.likes.util.CommentLikeStatus;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.notification.service.NotificationService;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
@@ -38,6 +38,7 @@ public class CommentService {
     private final CommentLikeRepository commentLikeRepository;
     private final TravelRepository travelRepository;
     private final S3Uploader s3Uploader;
+    private final NotificationService notificationService;
 
     // Create
     @Transactional
@@ -64,6 +65,10 @@ public class CommentService {
                 relatedType,
                 relatedNumber
         ));
+
+        //create notification to Host and Enrolled Users
+        notificationService.createCommentNotifications(relatedType, relatedNumber);
+
         return savedComment;
     }
 

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
@@ -9,6 +9,8 @@ public interface EnrollmentCustomRepository {
 
     List<EnrollmentResponse> findEnrollmentsByTravelNumber(int travelNumber);
 
+    List<Integer> findEnrolledUserNumbersByTravelNumber(int travelNumber);
+
     List<Tuple> findEnrollmentsByUserNumber(int userNumber);
 
 }

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
@@ -48,6 +48,17 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
     }
 
     @Override
+    public List<Integer> findEnrolledUserNumbersByTravelNumber(int travelNumber) {
+        return queryFactory
+                .select(enrollment.userNumber)
+                .from(enrollment)
+                .where(
+                        enrollment.travelNumber.eq(travelNumber),
+                        enrollment.status.in(List.of(EnrollmentStatus.PENDING, EnrollmentStatus.ACCEPTED))
+                ).fetch();
+    }
+
+    @Override
     public List<Tuple> findEnrollmentsByUserNumber(int userNumber) {
         return queryFactory
                 .select(enrollment.number, travel.number, enrollment.status)

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -49,7 +49,7 @@ public class EnrollmentService {
         enrollmentRepository.save(created);
 
         //알림
-        notificationService.createEnrollNotificatonToHost(targetTravel); //주최자
+        notificationService.createEnrollNotificationToHost(targetTravel); //주최자
         notificationService.createEnrollNotification(targetTravel, user); //신청자
     }
 

--- a/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/Notification.java
@@ -4,19 +4,21 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
+@SuperBuilder
 @Table(name = "notifications")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "dtype", discriminatorType = DiscriminatorType.STRING, length = 20)
 @Entity
-public abstract class Notification {
+public class Notification {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,8 +40,6 @@ public abstract class Notification {
 
     @Column(name = "notification_read", nullable = false)
     private Boolean isRead;
-
-    //TODO: 이미지
 
 
     public Notification(

--- a/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
@@ -28,6 +28,18 @@ public enum NotificationMessageType {
         public String getContent(String travelTitle) {
             return String.format("[%s]에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?", travelTitle);
         }
+    },
+
+    TRAVEL_NEW_COMMENT_HOST("멤버 댓글 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("개설하신 [%s]에 멤버 댓글이 달렸어요. 확인해보세요.", travelTitle);
+        }
+    },
+
+    TRAVEL_NEW_COMMENT_ENROLLMENT("멤버 댓글 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("참가 신청하신 [%s]에 멤버 댓글이 달렸어요. 확인해보세요.", travelTitle);
+        }
     };
 
     private final String title;

--- a/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
@@ -4,20 +4,21 @@ import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @DiscriminatorValue("travel")
 public class TravelNotification extends Notification {
 
-    @Column(name = "travel_number", nullable = false)
+    @Column(name = "travel_number")
     private Integer travelNumber;
 
     @Column(name = "travel_title", length = 20)
@@ -27,7 +28,6 @@ public class TravelNotification extends Notification {
     private LocalDate travelDueDate;
 
 
-    @Builder
     public TravelNotification(
             Long number, LocalDateTime createdAt, Integer receiverNumber,
             String title, String content, Boolean isRead,

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -57,4 +57,22 @@ public class NotificationMaker {
                 .build();
     }
 
+    public static Notification travelNewCommentMessageToHost(Travel targetTravel) {
+        return Notification.builder()
+                .receiverNumber(targetTravel.getUserNumber())
+                .title(NotificationMessageType.TRAVEL_NEW_COMMENT_HOST.getTitle())
+                .content(NotificationMessageType.TRAVEL_NEW_COMMENT_HOST.getContent(targetTravel.getTitle()))
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelNewCommentMessageToEnrollments(Travel targetTravel, int enrolledUserNumber) {
+        return Notification.builder()
+                .receiverNumber(enrolledUserNumber)
+                .title(NotificationMessageType.TRAVEL_NEW_COMMENT_ENROLLMENT.getTitle())
+                .content(NotificationMessageType.TRAVEL_NEW_COMMENT_ENROLLMENT.getContent(targetTravel.getTitle()))
+                .isRead(false)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행 콘텐츠에 댓글이 추가될 경우 Notification알림을 생성한다
- 알림 수신자: 여행 주최자, 여행 신청자
- 알림 title: `멤버 댓글 알림`
- 주최자 content: `개설하신 [여행title]에 멤버 댓글이 달렸어요. 확인해보세요.`
- 신청자 content: `참가 신청하신 [여행title]에 멤버 댓글이 달렸어요. 확인해보세요.`

구현 관련 사항
- 댓글 알림은 여행 신청/수락 알림과는 달리 추가적인 데이터가 필요하지 않음
  - 추상 클래스로 설정한 Notification을 일반 클래스로 변경함
  - Notification, TravelNotification의 `@Builder`를 `@SuperBuilder` 어노테이션으로 변경함
- 댓글 추가에 대한 알림 생성 작업은 NotificationService에서 비동기로 처리하도록 설정
  - 특정 여행에 대해 PENDING, ACCEPTED 상태인 Enrollment의 userNumber 목록을 가져온다
  - 각 userNumber에 대해 Notification을 생성해 저장한다


## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
