### PR TITLE
fix(deploy): Github Actions Build Permission 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,9 @@ jobs:
         run: echo "${{ secrets.APPLICATION_CREDENTIALS }}" > ./src/test/resources/application-credentials.yml
 
       - name: Test and Build
-        run: ./gradlew clean build
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build
 
       - name: Change build result file name
         run: mv ./build/libs/*SNAPSHOT.jar ./project.jar


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
* main 브랜치에 merge하는 과정에서 아래의 오류가 발생해 merge가 fail하는 문제
<img width="534" alt="image" src="https://github.com/user-attachments/assets/9714a384-ae6a-4136-885d-e1ea49ebd774">

&nbsp;

* Build 할 때 Permission을 허용하는 코드를 추가함
```
  - name: Test and Build
    run: |
      chmod +x ./gradlew
      ./gradlew clean build
```

## 🔖 리뷰 요구사항(선택)
.


## ✅ PR Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
