### PR TITLE
fix: 여행 콘텐츠 추천 목록 조회 로직 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/member/service/MemberService.java
+++ b/src/main/java/swyp/swyp6_team7/member/service/MemberService.java
@@ -1,20 +1,17 @@
 package swyp.swyp6_team7.member.service;
 
-import io.jsonwebtoken.Jwt;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.auth.jwt.JwtProvider;
 import swyp.swyp6_team7.member.dto.UserRequestDto;
 import swyp.swyp6_team7.member.entity.*;
 import swyp.swyp6_team7.member.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import swyp.swyp6_team7.profile.dto.ProfileCreateRequest;
 import swyp.swyp6_team7.profile.service.ProfileService;
-
-import org.springframework.security.core.GrantedAuthority;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.domain.UserTagPreference;
 import swyp.swyp6_team7.tag.repository.UserTagPreferenceRepository;
@@ -42,16 +39,14 @@ public class MemberService {
 
 
     @Autowired
-
-
-    public MemberService(UserRepository userRepository,
-                         PasswordEncoder passwordEncoder,
-                         ProfileService profileService,
-                         @Lazy JwtProvider jwtProvider,
-                         TagService tagService,
-                         UserTagPreferenceRepository userTagPreferenceRepository,
-                         MemberDeletedService memberDeletedService){
-
+    public MemberService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            ProfileService profileService,
+            @Lazy JwtProvider jwtProvider,
+            TagService tagService,
+            UserTagPreferenceRepository userTagPreferenceRepository,
+            MemberDeletedService memberDeletedService) {
 
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
@@ -68,19 +63,6 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
 
-    @Transactional(readOnly = true)
-    public List<String> findPreferredTagsByEmail(String email) {
-        Users user = userRepository.findByUserEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
-        if (user.getPreferredTags().isEmpty()) {
-            throw new IllegalArgumentException("사용자 태그가 설정되어 있지 않습니다.");
-        }
-
-        return user.getPreferredTags().stream()
-                .map(tag -> tag.getName())
-                .toList();
-    }
 
     public Map<String, Object> signUp(UserRequestDto userRequestDto) {
 
@@ -104,7 +86,7 @@ public class MemberService {
         AgeGroup ageGroup;
         try {
 
-            ageGroup =  AgeGroup.fromValue(userRequestDto.getAgegroup());
+            ageGroup = AgeGroup.fromValue(userRequestDto.getAgegroup());
 
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid age group provided.");
@@ -158,7 +140,7 @@ public class MemberService {
 
         // JWT 발급
         long tokenExpirationTime = 3600000; // 토큰 만료 시간 추가(1시간)
-        String token = jwtProvider.createToken(newUser.getEmail(), newUser.getUserNumber(),roles, tokenExpirationTime);
+        String token = jwtProvider.createToken(newUser.getEmail(), newUser.getUserNumber(), roles, tokenExpirationTime);
 
         // 응답 데이터에 userId와 accessToken 포함
         Map<String, Object> response = new HashMap<>();
@@ -217,7 +199,7 @@ public class MemberService {
 
         // JWT 발급
         long tokenExpirationTime = 3600000; // 토큰 만료 시간 1시간
-        String token = jwtProvider.createToken(newAdmin.getUserEmail(),newAdmin.getUserNumber(), roles, tokenExpirationTime);
+        String token = jwtProvider.createToken(newAdmin.getUserEmail(), newAdmin.getUserNumber(), roles, tokenExpirationTime);
 
         // 응답 데이터
         Map<String, Object> response = new HashMap<>();
@@ -253,6 +235,7 @@ public class MemberService {
         return userRepository.findByUserEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다: " + email));
     }
+
     @Transactional
     public void deleteUser(Integer userNumber) {
         Optional<Users> optionalUser = userRepository.findById(userNumber);

--- a/src/main/java/swyp/swyp6_team7/tag/repository/UserTagPreferenceRepository.java
+++ b/src/main/java/swyp/swyp6_team7/tag/repository/UserTagPreferenceRepository.java
@@ -1,7 +1,15 @@
 package swyp.swyp6_team7.tag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import swyp.swyp6_team7.tag.domain.UserTagPreference;
 
+import java.util.List;
+
 public interface UserTagPreferenceRepository extends JpaRepository<UserTagPreference, Integer> {
+
+    @Query("select t.tag.name from UserTagPreference t where t.user.userNumber = :userNumber")
+    List<String> findPreferenceTagsByUserNumber(@Param("userNumber") int userNumber);
+
 }

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
@@ -7,8 +7,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
+import swyp.swyp6_team7.tag.repository.UserTagPreferenceRepository;
 import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
@@ -26,7 +26,7 @@ import java.util.List;
 public class TravelHomeService {
 
     private final TravelRepository travelRepository;
-    private final MemberService memberService;
+    private final UserTagPreferenceRepository userTagPreferenceRepository;
 
     public Page<TravelRecentDto> getTravelsSortedByCreatedAt(PageRequest pageRequest) {
         Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
@@ -36,13 +36,10 @@ public class TravelHomeService {
     public Page<TravelRecommendDto> getRecommendTravelsByUser(PageRequest pageRequest, Principal principal) {
 
         Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
-        List<String> preferredTags = memberService.findPreferredTagsByEmail(principal.getName());
-        log.info("preferredTags: " + preferredTags);
+        List<String> preferredTags = userTagPreferenceRepository.findPreferenceTagsByUserNumber(loginUserNumber);
+        //log.info("preferredTags: " + preferredTags);
 
         Page<TravelRecommendDto> result = travelRepository.findAllByPreferredTags(pageRequest, loginUserNumber, preferredTags);
-        for (TravelRecommendDto dto : result.getContent()) {
-            log.info(String.format("TravelRecommendDto = %d, %s", dto.getTravelNumber(), dto.getTags().toString()));
-        }
 
         List<TravelRecommendDto> travels = new ArrayList<>(result.getContent());
         Collections.sort(travels, new TravelRecommendComparator());


### PR DESCRIPTION
## 🔗 Issue Number
.
## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
메인 화면의 추천 여행 콘텐츠 목록 조회 기능에서 사용자 선호 태그를 가져오는 과정을 수정함
요약: Users의 preferredTags가 아니라 UserTagPreference를 사용하도록 수정함
* 기존 로직 - MemberService
  * principal의 email을 이용해 Users를 찾는다
  * Users의 `Set<Tag> preferredTags`를 이용해 선호 태그를 가져온다
  * 만약, 태그가 없을 경우 예외를 던진다
  * stream map으로 각 Tag의 name을 가져온다
* 현재 로직 - TravelHomeService
  * MemberAuthorizeUtil을 이용해 로그인 사용자의 userNumber를 가져온다
  * UserTagPreferenceRepository의 `findPreferenceTagsByUserNumber` 메서드로 선호 태그 List<String>을 가져온다
     ``` 
     @Query("select t.tag.name from UserTagPreference t where t.user.userNumber = :userNumber")
      List<String> findPreferenceTagsByUserNumber(@Param("userNumber") int userNumber); 
     ```

## 🔖 리뷰 요구사항(선택)
.

## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
