### PR TITLE
fix:커뮤니티 이미지 정식 저장 안됨 오류 수정 / feat: 프로필 이미지 임시저장 기능 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/image/controller/ImageProfileController.java
+++ b/src/main/java/swyp/swyp6_team7/image/controller/ImageProfileController.java
@@ -38,6 +38,12 @@ public class ImageProfileController {
         return ResponseEntity.ok(response);
     }
 
+//    //임시 저장
+//    @PutMapping("/temp")
+//    public ResponseEntity<String> {
+//        return null;
+//    }
+
     //새로운 이미지 파일로 프로필 수정
     @PutMapping("")
     public ResponseEntity<ImageDetailResponseDto> updatedProfileImage(@RequestParam(value = "file") MultipartFile file, Principal principal) throws IOException {

--- a/src/main/java/swyp/swyp6_team7/image/dto/request/ImageCreateRequestDto.java
+++ b/src/main/java/swyp/swyp6_team7/image/dto/request/ImageCreateRequestDto.java
@@ -39,10 +39,11 @@ public class ImageCreateRequestDto {
 
         // 최소 필드만 받는 생성자 (프로필 이미지 기본 이미지용)
     @Builder
-    public ImageCreateRequestDto(String relatedType, int relatedNumber, int order, String url) {
+    public ImageCreateRequestDto(String relatedType, int relatedNumber, int order, String key, String url) {
         this.relatedType = relatedType;
         this.relatedNumber = relatedNumber;
         this.order = order;
+        this.key = key;
         this.url = url;
         this.uploadDate = LocalDateTime.now();
     }

--- a/src/main/java/swyp/swyp6_team7/image/dto/request/TempDeleteRequestDto.java
+++ b/src/main/java/swyp/swyp6_team7/image/dto/request/TempDeleteRequestDto.java
@@ -1,0 +1,13 @@
+package swyp.swyp6_team7.image.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TempDeleteRequestDto {
+
+    private String deletedTempUrl;
+}

--- a/src/main/java/swyp/swyp6_team7/image/dto/request/TempUploadRequestDto.java
+++ b/src/main/java/swyp/swyp6_team7/image/dto/request/TempUploadRequestDto.java
@@ -1,0 +1,12 @@
+package swyp.swyp6_team7.image.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TempUploadRequestDto {
+    private String imageUrl;
+}

--- a/src/main/java/swyp/swyp6_team7/image/s3/S3Uploader.java
+++ b/src/main/java/swyp/swyp6_team7/image/s3/S3Uploader.java
@@ -87,7 +87,9 @@ public class S3Uploader {
     //해당 경로에 특정 파일이 존재하는지 확인하는 메소드 (key로 확인)
     public boolean existObject(String key) {
         return amazonS3.doesObjectExist(s3Component.getBucket(), key);
+
     }
+
 
     // S3 파일 삭제 메소드
     public void deleteFile(String S3Key) {
@@ -103,9 +105,6 @@ public class S3Uploader {
             System.err.println("S3 파일 삭제 실패: " + e.getMessage());
         }
     }
-
-
-
 
 
     // S3 key 로 URL 추출
@@ -138,17 +137,16 @@ public class S3Uploader {
     }
 
 
-
     // 이미지 경로 이동 메서드
     public String moveImage(String sourceKey, String destinationKey) {
-        
+
         //기존 경로에서 이미지 복사
         copyImage(sourceKey, destinationKey);
-        
-        //기존 경로의 이미지 삭제
-       deleteFile(sourceKey);
 
-       //경로 이동 후 path 리턴
+        //기존 경로의 이미지 삭제
+        deleteFile(sourceKey);
+
+        //경로 이동 후 path 리턴
         return destinationKey;
     }
 

--- a/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
+++ b/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
@@ -174,4 +174,13 @@ public class ImageProfileService {
 
         }
     }
+
+    //임시저장
+//    public String temporaryImage (MultipartFile file, int userNumber) throws IOException {
+//        String relatedType = "profile";
+//
+//        String temKey = S3Uploader.uploadInTemporary(file, relatedType);
+//
+//    }
+
 }

--- a/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
+++ b/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
@@ -2,6 +2,7 @@ package swyp.swyp6_team7.image.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,6 +12,7 @@ import swyp.swyp6_team7.image.dto.request.ImageUpdateRequestDto;
 import swyp.swyp6_team7.image.dto.response.ImageDetailResponseDto;
 import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.image.s3.S3Uploader;
+import swyp.swyp6_team7.image.util.S3KeyHandler;
 import swyp.swyp6_team7.image.util.StorageNameHandler;
 
 
@@ -27,60 +29,40 @@ public class ImageProfileService {
     private final S3Uploader s3Uploader;
     private final ImageService imageService;
     private final StorageNameHandler storageNameHandler;
+    private final S3KeyHandler s3KeyHandler;
 
 
     //프로필 처음 생성 시 이미지 처리
     @Transactional
-    public ImageDetailResponseDto initializeDefaultProfileImage(int relatedNumber) {
-        ImageDetailResponseDto response = uploadDefaultImage(relatedNumber, 1);
+    public ImageDetailResponseDto initializeDefaultProfileImage(int userNumber) {
+        String url = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
+        String defaultKey = s3KeyHandler.getKeyByUrl(url);
 
-        return response;
-    }
-
-    //프로필 이미지 파일로 업로드
-    @Transactional
-    public ImageDetailResponseDto uploadProfileImage(int relatedNumber, MultipartFile file) throws IOException {
-
-
-        int order = 0;
-        String relatedType = "profile";
-
-        //기존 이미지가 있는지 확인
-        Optional<Image> image = imageRepository.findByRelatedTypeAndRelatedNumberAndOrder(relatedType, relatedNumber, order);
-
-        if(image.isPresent()) {
-            //기존 이미지 S3에서 삭제
-            s3Uploader.deleteFile(image.get().getKey());
-        }
-        
-        //이미지 업로드
-        String key = s3Uploader.upload(file, relatedType, relatedNumber, order);
-        String savedImageUrl = s3Uploader.getImageUrl(key);
-
-        //DB 수정
-        // 최소 필드를 사용하여 DTO 생성
-        // 메타 데이터 뽑아서 update dto에 담기
-        ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
-                .originalName(file.getOriginalFilename())
-                .storageName(storageNameHandler.generateUniqueFileName(file.getOriginalFilename()))
-                .size(file.getSize())
-                .format(file.getContentType())
-                .relatedType(relatedType)
-                .relatedNumber(relatedNumber)
-                .order(order)
-                .key(key)
-                .url(savedImageUrl)
+        //DB insert 동작
+        ImageCreateRequestDto imageCreateDto = ImageCreateRequestDto.builder()
+                .relatedType("profile")
+                .relatedNumber(userNumber)
+                .order(0)
+                .key(defaultKey)
+                .url(url)
                 .build();
 
-        return imageService.updateDB(relatedType, relatedNumber, 0, updateRequest);
+        // DB에 저장
+        Image image = imageCreateDto.toImageEntity();
+        Image uploadedImage = imageRepository.save(image);
+
+        return new ImageDetailResponseDto(uploadedImage);
     }
 
-    //프로필 이미지 기본 이미지로 등록/수정
+    //프로필 이미지 기본 이미지로 수정
     @Transactional
-    public ImageDetailResponseDto uploadDefaultImage(int relatedNumber, int defaultProfileImageNumber) {
+    public ImageDetailResponseDto updateProfileByDefaultUrl(int relatedNumber, int defaultProfileImageNumber) {
         String relatedType = "profile";
         int order = 0;
         String url = "";
+
+        Optional<Image> searchImage = imageRepository.findByRelatedTypeAndRelatedNumberAndOrder(relatedType, relatedNumber, 0);
+
 
         switch (defaultProfileImageNumber) {
 
@@ -108,79 +90,76 @@ public class ImageProfileService {
                 throw new IllegalArgumentException("유효하지 않은 default image number 입니다: " + defaultProfileImageNumber);
         }
 
+        String presentKey = searchImage.get().getKey();
 
-        ImageDetailResponseDto response = updateProfileByDefaultUrl(relatedType, relatedNumber, url);
-        return response;
+        //이전 이미지가 파일 업로드인지 default 이미지인지 확인
+        //key가 "images/profile/relatedNumber"로 시작하면, 이전 이미지는 파일 업로드 이미지
+        if (presentKey.startsWith("images/profile/" + relatedNumber)) {
+            //이미지 삭제
+            s3Uploader.deleteFile(presentKey);
+        }
+        //key가 "images/profile/default"로 시작하면, 이전 이미지는 디폴트 이미지
+        else if (presentKey.startsWith("images/profile/default")) {
+            //이미지 삭제 동작 필요 없음
+        } else {
+            throw new IllegalArgumentException("업데이트 전 DB  데이터에 오류가 있습니다.");
+        }
+        String defaultKey = s3KeyHandler.getKeyByUrl(url);
+        // DB 업데이트 동작
+        ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+                .relatedType(relatedType)
+                .relatedNumber(relatedNumber)
+                .order(0)
+                .key(defaultKey)
+                .url(url)
+                .build();
+
+        return imageService.updateDB(relatedType, relatedNumber, 0, updateRequest);
     }
 
-
-    //기존 이미지를 지우고 url로 이미지 수정 (프로필)
+    //기존 이미지를 지우고 url로 이미지 수정 (이미지 정식 저장)
     @Transactional
-    public ImageDetailResponseDto updateProfileByDefaultUrl(String relatedType, int relatedNumber, String url) {
+    public ImageDetailResponseDto uploadProfileImage(String relatedType, int relatedNumber, String tempUrl) {
         //DB에서 이미지 찾기
         Optional<Image> searchImage = imageRepository.findByRelatedTypeAndRelatedNumberAndOrder(relatedType, relatedNumber, 0);
+        String presentKey = searchImage.get().getKey();
 
-        //관련 이미지 행이 조회 됐을 때
-        if (searchImage.isPresent()) {
-
-            // original name이 null이 아니라면(= 기존 이미지가 파일로 업로드 한 사진)
-
-            if (searchImage.get().getOriginalName() != null) {
-                // S3에서 기존 파일 삭제
-                s3Uploader.deleteFile(searchImage.get().getKey());
-
-                //DB 수정
-                // 최소 필드를 사용하여 DTO 생성
-                ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
-                        .relatedType(relatedType)
-                        .relatedNumber(relatedNumber)
-                        .order(0)
-                        .key(null)
-                        .url(url) // 새 이미지 URL
-                        .build();
-
-                return imageService.updateDB(relatedType, relatedNumber, 0, updateRequest);
-
-                // original name이 null이 라면 (=기존 이미지를 url로 저장)
-            } else {
-
-                ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
-                        .relatedType(relatedType)
-                        .relatedNumber(relatedNumber)
-                        .order(0)
-                        .key(null)
-                        .url(url) // 새 이미지 URL
-                        .build();
-
-                return imageService.updateDB(relatedType, relatedNumber, 0, updateRequest);
-
-            }
-
-            //관련 이미지 행이 조회되지 않았을 경우 (= 프로필 이미지 행이 insert 되기 전)
-        } else {
-            //DB insert 동작
-            ImageCreateRequestDto imageCreateDto = ImageCreateRequestDto.builder()
-                    .relatedType(relatedType)
-                    .relatedNumber(relatedNumber)
-                    .order(0)
-                    .url(url)
-                    .build();
-
-            // DB에 저장
-            Image image = imageCreateDto.toImageEntity();
-
-            Image uploadedImage = imageRepository.save(image);
-            return new ImageDetailResponseDto(uploadedImage);
-
+        //이전 이미지가 파일 업로드인지 default 이미지인지 확인
+        //key가 "images/profile/relatedNumber"로 시작하면, 이전 이미지는 파일 업로드 이미지
+        if (presentKey.startsWith("images/profile/" + relatedNumber)) {
+            //이미지 삭제
+            s3Uploader.deleteFile(presentKey);
         }
+        //key가 "images/profile/default"로 시작하면, 이전 이미지는 디폴트 이미지
+        else if (presentKey.startsWith("images/profile/default")) {
+            //이미지 삭제 동작 필요 없음
+        } else {
+            throw new IllegalArgumentException("업데이트 전 DB 데이터에 오류가 있습니다.");
+        }
+
+        //storage name 추출
+        String storageName = storageNameHandler.extractStorageName(s3KeyHandler.getKeyByUrl(tempUrl));
+        //sourceKey 추출
+
+        String tempKey = s3KeyHandler.getKeyByUrl(tempUrl);
+        //새로운 key 생성
+        String newKey = s3KeyHandler.generateS3Key(relatedType, relatedNumber, storageName, 0);
+
+        //정식 경로로 이동
+        s3Uploader.moveImage(tempKey, newKey);
+        //새로운 url 추출
+        String newUrl = s3Uploader.getImageUrl(newKey);
+
+        // DB 업데이트 동작
+        ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+                .relatedType(relatedType)
+                .relatedNumber(relatedNumber)
+                .order(0)
+                .key(newKey)
+                .url(newUrl)
+                .build();
+
+        return imageService.updateDB(relatedType, relatedNumber, 0, updateRequest);
+
     }
-
-    //임시저장
-//    public String temporaryImage (MultipartFile file, int userNumber) throws IOException {
-//        String relatedType = "profile";
-//
-//        String temKey = S3Uploader.uploadInTemporary(file, relatedType);
-//
-//    }
-
 }

--- a/src/main/java/swyp/swyp6_team7/image/service/ImageService.java
+++ b/src/main/java/swyp/swyp6_team7/image/service/ImageService.java
@@ -11,6 +11,7 @@ import swyp.swyp6_team7.image.dto.request.ImageUpdateRequestDto;
 import swyp.swyp6_team7.image.dto.response.ImageDetailResponseDto;
 import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.image.s3.S3Uploader;
+import swyp.swyp6_team7.image.util.S3KeyHandler;
 import swyp.swyp6_team7.image.util.StorageNameHandler;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ public class ImageService {
     private final ImageRepository imageRepository;
     private final S3Uploader s3Uploader;
     private final StorageNameHandler storageNameHandler;
+    private final S3KeyHandler s3KeyHandler;
 
 
     //단일 파일 이미지 업로드 후 DB 저장
@@ -127,6 +129,23 @@ public class ImageService {
                 .orElseThrow(() -> new IllegalArgumentException("이미지 상세 조회 : 해당 이미지를 찾을 수 없습니다." + relatedType + ":" + relatedNumber));
 
         return new ImageDetailResponseDto(image);
+    }
+
+    //임시저장
+    public String temporaryImage (MultipartFile file) throws IOException {
+        String relatedType = "profile";
+
+        //임시 저장 경로에 업로드
+        String tempKey = s3Uploader.uploadInTemporary(file, relatedType);
+        String temUrl = s3Uploader.getImageUrl(tempKey);
+
+        return temUrl;
+    }
+
+    //임시 저장 삭제
+    public void deleteTempImage(String temUrl) {
+        String tempKey = s3KeyHandler.getKeyByUrl(temUrl);
+        s3Uploader.deleteFile(tempKey);
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/image/util/S3KeyHandler.java
+++ b/src/main/java/swyp/swyp6_team7/image/util/S3KeyHandler.java
@@ -92,16 +92,19 @@ public class S3KeyHandler {
 
 
     //url로 key를 추출하는 메소드
-    public String getKeyByUrl(String Url) {
+    public String getKeyByUrl(String url) {
+        System.out.println("S3 key로 url 추출 메소드 동작, url : " + url);
         String bucketName = s3Component.getBucket();
         String region = "ap-northeast-2";
         String S3_URL_PREFIX = "https://"+ bucketName +".s3." + region + ".amazonaws.com/";
+        System.out.println("S3 URL Prefix: " + S3_URL_PREFIX);
 
         // URL이 올바른 형식인지 확인
-        if (!Url.startsWith(S3_URL_PREFIX)) {
+        if (!url.startsWith(S3_URL_PREFIX)) {
             throw new IllegalArgumentException("URL 형식이 올바르지 않습니다. S3 URL인지 확인해주세요");
         }
-        String key = Url.replace(S3_URL_PREFIX, "");
+        String key = url.replace(S3_URL_PREFIX, "");
+
 
         return key;
     }

--- a/src/main/java/swyp/swyp6_team7/image/util/StorageNameHandler.java
+++ b/src/main/java/swyp/swyp6_team7/image/util/StorageNameHandler.java
@@ -33,4 +33,9 @@ public class StorageNameHandler {
         return UUID.randomUUID().toString();
     }
 
+    //key로 storageName 추출
+    public String extractStorageName(String s3Key) {
+        // 마지막 '/' 이후의 문자열을 추출
+        return s3Key.substring(s3Key.lastIndexOf('/') + 1);
+    }
 }


### PR DESCRIPTION
## PR 유형
- [V] 새로운 기능 추가
- [V] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
fix:커뮤니티 이미지 정식 저장 안됨 오류 수정 / feat: 프로필 이미지 임시저장 기능 추가

커뮤니티 이미지 정식 저장 안됨 오류 수정
-> 조회 업데이트에서 빈 배열 선언 시 사이즈가 0인 배열 선언해서 배열에 데이터 담을때 index 0 에러 발생해서 rollback 되는 오류 였음

프로필 이미지 임시저장 기능 추가

## ✅ PR Check List
- [V] 코드가 정상적으로 컴파일되나요?
- [V] 테스트 코드를 통과했나요?
- [V] merge할 브랜치의 위치를 확인했나요?
