### PR TITLE
fix:프로필 이미지 임시저장 response dto에 담기

### DIFF
--- a/src/main/java/swyp/swyp6_team7/image/controller/ImageProfileController.java
+++ b/src/main/java/swyp/swyp6_team7/image/controller/ImageProfileController.java
@@ -10,6 +10,7 @@ import swyp.swyp6_team7.image.dto.request.ImageDefaultRequestDto;
 import swyp.swyp6_team7.image.dto.request.TempDeleteRequestDto;
 import swyp.swyp6_team7.image.dto.request.TempUploadRequestDto;
 import swyp.swyp6_team7.image.dto.response.ImageDetailResponseDto;
+import swyp.swyp6_team7.image.dto.response.ImageTempResponseDto;
 import swyp.swyp6_team7.image.service.ImageProfileService;
 import swyp.swyp6_team7.image.service.ImageService;
 import swyp.swyp6_team7.member.service.MemberService;
@@ -42,10 +43,10 @@ public class ImageProfileController {
 
     //임시 저장
     @PostMapping("/temp")
-    public ResponseEntity<String> createTempImage (@RequestParam(value = "file") MultipartFile file, Principal principal) throws IOException{
+    public ResponseEntity<ImageTempResponseDto> createTempImage (@RequestParam(value = "file") MultipartFile file, Principal principal) throws IOException{
 
-        String tempUrl = imageService.temporaryImage(file);
-        return ResponseEntity.ok(tempUrl);
+        ImageTempResponseDto response = imageService.temporaryImage(file);
+        return ResponseEntity.ok(response);
     }
 
     //임시 저장 삭제

--- a/src/main/java/swyp/swyp6_team7/image/dto/response/ImageTempResponseDto.java
+++ b/src/main/java/swyp/swyp6_team7/image/dto/response/ImageTempResponseDto.java
@@ -1,0 +1,10 @@
+package swyp.swyp6_team7.image.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageTempResponseDto {
+    private String tempUrl;
+}

--- a/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
+++ b/src/main/java/swyp/swyp6_team7/image/service/ImageProfileService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import swyp.swyp6_team7.image.domain.Image;
 import swyp.swyp6_team7.image.dto.request.ImageCreateRequestDto;
 import swyp.swyp6_team7.image.dto.request.ImageUpdateRequestDto;
@@ -14,9 +13,6 @@ import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.image.s3.S3Uploader;
 import swyp.swyp6_team7.image.util.S3KeyHandler;
 import swyp.swyp6_team7.image.util.StorageNameHandler;
-
-
-import java.io.IOException;
 import java.util.Optional;
 
 @Slf4j

--- a/src/main/java/swyp/swyp6_team7/image/service/ImageService.java
+++ b/src/main/java/swyp/swyp6_team7/image/service/ImageService.java
@@ -9,6 +9,7 @@ import swyp.swyp6_team7.image.domain.Image;
 import swyp.swyp6_team7.image.dto.request.ImageCreateRequestDto;
 import swyp.swyp6_team7.image.dto.request.ImageUpdateRequestDto;
 import swyp.swyp6_team7.image.dto.response.ImageDetailResponseDto;
+import swyp.swyp6_team7.image.dto.response.ImageTempResponseDto;
 import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.image.s3.S3Uploader;
 import swyp.swyp6_team7.image.util.S3KeyHandler;
@@ -132,14 +133,15 @@ public class ImageService {
     }
 
     //임시저장
-    public String temporaryImage (MultipartFile file) throws IOException {
+    public ImageTempResponseDto temporaryImage (MultipartFile file) throws IOException {
         String relatedType = "profile";
 
         //임시 저장 경로에 업로드
         String tempKey = s3Uploader.uploadInTemporary(file, relatedType);
         String temUrl = s3Uploader.getImageUrl(tempKey);
 
-        return temUrl;
+
+        return new ImageTempResponseDto(temUrl);
     }
 
     //임시 저장 삭제


### PR DESCRIPTION
## PR 유형
- [ ] 새로운 기능 추가
- [V] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용

임시 저장 시 response 문자열 깨짐 문제 해결
프로필 이미지 임시저장 response dto에 담기


## ✅ PR Check List
- [V] 코드가 정상적으로 컴파일되나요?
- [V] 테스트 코드를 통과했나요?
- [V] merge할 브랜치의 위치를 확인했나요?
