### PR TITLE
feat(enrollment): 신청목록 조회DTO 사용자 프로필 url 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/enrollment/dto/EnrollmentResponse.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/dto/EnrollmentResponse.java
@@ -19,6 +19,7 @@ public class EnrollmentResponse {
     private long enrollmentNumber;
     private String userName;
     private String userAgeGroup;
+    private String profileUrl;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime enrolledAt;
     private String message;
@@ -27,13 +28,13 @@ public class EnrollmentResponse {
     @Builder
     @QueryProjection
     public EnrollmentResponse(
-            long enrollmentNumber, String userName,
-            AgeGroup ageGroup, LocalDateTime enrolledAt,
-            String message, EnrollmentStatus status
+            long enrollmentNumber, String userName, AgeGroup ageGroup, String profileUrl,
+            LocalDateTime enrolledAt, String message, EnrollmentStatus status
     ) {
         this.enrollmentNumber = enrollmentNumber;
         this.userName = userName;
         this.userAgeGroup = ageGroup.getValue();
+        this.profileUrl = profileUrl;
         this.enrolledAt = enrolledAt;
         this.message = message;
         this.status = status.toString();

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 import swyp.swyp6_team7.enrollment.domain.QEnrollment;
 import swyp.swyp6_team7.enrollment.dto.EnrollmentResponse;
 import swyp.swyp6_team7.enrollment.dto.QEnrollmentResponse;
+import swyp.swyp6_team7.image.domain.QImage;
 import swyp.swyp6_team7.member.entity.QUsers;
 import swyp.swyp6_team7.travel.domain.QTravel;
 
@@ -25,6 +26,7 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
     QEnrollment enrollment = QEnrollment.enrollment;
     QUsers users = QUsers.users;
     QTravel travel = QTravel.travel;
+    QImage image = QImage.image;
 
 
     @Override
@@ -34,12 +36,15 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
                         enrollment.number,
                         users.userName,
                         users.userAgeGroup,
+                        image.url,
                         enrollment.createdAt,
                         enrollment.message,
                         enrollment.status
                 ))
                 .from(enrollment)
                 .leftJoin(users).on(enrollment.userNumber.eq(users.userNumber))
+                .leftJoin(image).on(enrollment.userNumber.eq(image.relatedNumber)
+                        .and(image.relatedType.eq("profile")).and(image.order.eq(0)))
                 .where(
                         enrollment.travelNumber.eq(travelNumber),
                         enrollment.status.eq(EnrollmentStatus.PENDING))


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
* 여행 콘텐츠 신청 목록 조회 기능 수정
  * 기존의 신청자 관련 데이터(userNumber, userAgeGroup)에 사용자 프로필(profileUrl) 추가함
* `EnrollmentCustomRepositoryImpl`의 `findEnrollmentsByTravelNumber` 로직 수정
  * PENDING 상태의 신청서를 조회하는 메서드이다
  * Image 테이블을 left join해 3가지 조건을 만족하는 데이터에 대해 image.url을 가져온다
    ```
    .leftJoin(image).on(enrollment.userNumber.eq(image.relatedNumber)
                          .and(image.relatedType.eq("profile"))
                          .and(image.order.eq(0)))
    ```



## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
