### PR TITLE
feat(companion): 여행 동행 목록 조회 사용자 프로필 url 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/companion/dto/CompanionInfoDto.java
+++ b/src/main/java/swyp/swyp6_team7/companion/dto/CompanionInfoDto.java
@@ -10,13 +10,15 @@ public class CompanionInfoDto {
     private Integer userNumber;
     private String userName;
     private String ageGroup;
+    private String profileUrl;
 
 
     @QueryProjection
-    public CompanionInfoDto(Integer userNumber, String userName, AgeGroup ageGroup) {
+    public CompanionInfoDto(Integer userNumber, String userName, AgeGroup ageGroup, String profileUrl) {
         this.userNumber = userNumber;
         this.userName = userName;
         this.ageGroup = ageGroup.getValue();
+        this.profileUrl = profileUrl;
     }
 
     @Override
@@ -25,6 +27,7 @@ public class CompanionInfoDto {
                 "userNumber=" + userNumber +
                 ", userName='" + userName + '\'' +
                 ", ageGroup='" + ageGroup + '\'' +
+                ", profileUrl='" + profileUrl + '\'' +
                 '}';
     }
 }

--- a/src/main/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 import swyp.swyp6_team7.companion.domain.QCompanion;
 import swyp.swyp6_team7.companion.dto.CompanionInfoDto;
 import swyp.swyp6_team7.companion.dto.QCompanionInfoDto;
+import swyp.swyp6_team7.image.domain.QImage;
 import swyp.swyp6_team7.member.entity.QUsers;
 
 import java.util.List;
@@ -20,6 +21,7 @@ public class CompanionCustomRepositoryImpl implements CompanionCustomRepository 
 
     QCompanion companion = QCompanion.companion;
     QUsers users = QUsers.users;
+    QImage image = QImage.image;
 
 
     @Override
@@ -28,10 +30,13 @@ public class CompanionCustomRepositoryImpl implements CompanionCustomRepository 
                 .select(new QCompanionInfoDto(
                         users.userNumber,
                         users.userName,
-                        users.userAgeGroup
+                        users.userAgeGroup,
+                        image.url
                 ))
                 .from(companion)
                 .leftJoin(users).on(companion.userNumber.eq(users.userNumber))
+                .leftJoin(image).on(companion.userNumber.eq(image.relatedNumber)
+                        .and(image.relatedType.eq("profile")).and(image.order.eq(0)))
                 .where(companion.travel.number.eq(travelNumber))
                 .fetch();
     }

--- a/src/main/java/swyp/swyp6_team7/companion/service/CompanionService.java
+++ b/src/main/java/swyp/swyp6_team7/companion/service/CompanionService.java
@@ -17,13 +17,7 @@ public class CompanionService {
 
 
     public List<CompanionInfoDto> findCompanionsByTravelNumber(int travelNumber) {
-        List<CompanionInfoDto> companions = companionRepository
-                .findCompanionInfoByTravelNumber(travelNumber);
-
-        for (CompanionInfoDto companion : companions) {
-            log.info("companion = " + companion.toString());
-        }
-
+        List<CompanionInfoDto> companions = companionRepository.findCompanionInfoByTravelNumber(travelNumber);
         return companions;
     }
 


### PR DESCRIPTION
## 🔗 Issue Number
.

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
* 여행 콘텐츠 동행자 목록 조회 기능 수정
* `CompanionInfoDto`에 사용자 프로필 url 필드(profileUrl) 추가
  * 기존: 각 사용자에 대해 userNumber, userName, ageGroup
  * 현재: 기존 데이터에 사용자 프로필 url String 추가
* `CompanionCustomRepositoryImpl` 수정
  * `findCompanionInfoByTravelNumber` 메서드에서 Image 테이블 left join 후 image.url을 가져온다
    ```
      .leftJoin(image).on(companion.userNumber.eq(image.relatedNumber)
                          .and(image.relatedType.eq("profile")).and(image.order.eq(0)))
    ```


## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
