### PR TITLE
refactor: Travel CRUD, Home, Search 관련 기능 리팩토링

### DIFF
--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -4,22 +4,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
-import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.service.TravelService;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -79,37 +73,6 @@ public class TravelController {
         logger.info("Travel 삭제 완료 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-
-    @GetMapping("/api/travels/search")
-    public ResponseEntity<Page<TravelSearchDto>> search(
-            @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "5") int size,
-            @RequestParam(name = "keyword", required = false) String keyword,
-            @RequestParam(name = "location", required = false) List<String> selectedLocation,
-            @RequestParam(name = "gender", required = false) List<String> selectedGender,
-            @RequestParam(name = "person", required = false) List<String> selectedPerson,
-            @RequestParam(name = "period", required = false) List<String> selectedPeriod,
-            @RequestParam(name = "tags", required = false) List<String> selectedTags,
-            @RequestParam(name = "sorting", required = false) String selectedSortingType
-    ) {
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(page, size))
-                .keyword(keyword)
-                .locationTypes(selectedLocation)
-                .genderTypes(selectedGender)
-                .personTypes(selectedPerson)
-                .periodTypes(selectedPeriod)
-                .tags(selectedTags)
-                .sortingType(selectedSortingType)
-                .build();
-        log.info("Travel 조회 요청 - search condition: {}", condition.toString());
-
-        Page<TravelSearchDto> travels = travelService.search(condition);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(travels);
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -29,7 +29,7 @@ public class TravelController {
         logger.info("Travel 생성 요청 - userId: {}", loginUserNumber);
 
         Travel createdTravel = travelService.create(request, loginUserNumber);
-        logger.info("Travel 생성 완료 - createdTravel: {}", createdTravel);
+        logger.info("Travel 생성 완료 - userId: {}, createdTravel: {}", loginUserNumber, createdTravel);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(travelService.getDetailsByNumber(createdTravel.getNumber(), loginUserNumber));
@@ -58,7 +58,7 @@ public class TravelController {
         logger.info("Travel 수정 요청 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
 
         Travel updatedTravel = travelService.update(travelNumber, request, loginUserNumber);
-        logger.info("Travel 수정 완료 - updatedTravel: {}", updatedTravel);
+        logger.info("Travel 수정 요청 - userId: {}, updatedTravel: {}", loginUserNumber, updatedTravel);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(travelService.getDetailsByNumber(travelNumber, loginUserNumber));

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -2,12 +2,15 @@ package swyp.swyp6_team7.travel.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
@@ -16,7 +19,6 @@ import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.service.TravelService;
 
-import java.security.Principal;
 import java.util.List;
 
 @Slf4j
@@ -24,13 +26,17 @@ import java.util.List;
 @RestController
 public class TravelController {
 
+    private static final Logger logger = LoggerFactory.getLogger(TravelController.class);
     private final TravelService travelService;
 
     @PostMapping("/api/travel")
-    public ResponseEntity<TravelDetailResponse> create(
-            @RequestBody @Validated TravelCreateRequest request, Principal principal
-    ) {
-        Travel createdTravel = travelService.create(request, principal.getName());
+    public ResponseEntity<TravelDetailResponse> create(@RequestBody @Validated TravelCreateRequest request) {
+        int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+        logger.info("Travel 생성 요청 - userId: {}", loginUserNumber);
+
+        Travel createdTravel = travelService.create(request, loginUserNumber);
+        logger.info("Travel 생성 완료 - createdTravel: {}", createdTravel);
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(travelService.getDetailsByNumber(createdTravel.getNumber()));
     }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -46,7 +46,7 @@ public class TravelController {
             @PathVariable("travelNumber") int travelNumber
     ) {
         Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
-        logger.info("Travel 상세 조회 요청 - userId: {}", loginUserNumber);
+        logger.info("Travel 상세 조회 요청 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
 
         TravelDetailResponse travelDetails = travelService.getDetailsByNumber(travelNumber, loginUserNumber);
         travelService.addViewCount(travelNumber); //조회수 update
@@ -61,7 +61,7 @@ public class TravelController {
             @RequestBody TravelUpdateRequest request
     ) {
         int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
-        logger.info("Travel 수정 요청 - userId: {}", loginUserNumber);
+        logger.info("Travel 수정 요청 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
 
         Travel updatedTravel = travelService.update(travelNumber, request, loginUserNumber);
         logger.info("Travel 수정 완료 - updatedTravel: {}", updatedTravel);
@@ -73,9 +73,11 @@ public class TravelController {
     @DeleteMapping("/api/travel/{travelNumber}")
     public ResponseEntity delete(@PathVariable("travelNumber") int travelNumber) {
         int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
-        logger.info("Travel 삭제 요청 - userId: {}", loginUserNumber);
+        logger.info("Travel 삭제 요청 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
 
         travelService.delete(travelNumber, loginUserNumber);
+        logger.info("Travel 삭제 완료 - userId: {}, travelNumber: {}", loginUserNumber, travelNumber);
+
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -38,14 +38,17 @@ public class TravelController {
         logger.info("Travel 생성 완료 - createdTravel: {}", createdTravel);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(travelService.getDetailsByNumber(createdTravel.getNumber()));
+                .body(travelService.getDetailsByNumber(createdTravel.getNumber(), loginUserNumber));
     }
 
     @GetMapping("/api/travel/detail/{travelNumber}")
     public ResponseEntity<TravelDetailResponse> getDetailsByNumber(
             @PathVariable("travelNumber") int travelNumber
     ) {
-        TravelDetailResponse travelDetails = travelService.getDetailsByNumber(travelNumber);
+        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+        logger.info("Travel 상세 조회 요청 - userId: {}", loginUserNumber);
+
+        TravelDetailResponse travelDetails = travelService.getDetailsByNumber(travelNumber, loginUserNumber);
         travelService.addViewCount(travelNumber); //조회수 update
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -57,14 +60,22 @@ public class TravelController {
             @PathVariable("travelNumber") int travelNumber,
             @RequestBody TravelUpdateRequest request
     ) {
-        travelService.update(travelNumber, request);
+        int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+        logger.info("Travel 수정 요청 - userId: {}", loginUserNumber);
+
+        Travel updatedTravel = travelService.update(travelNumber, request, loginUserNumber);
+        logger.info("Travel 수정 완료 - updatedTravel: {}", updatedTravel);
+
         return ResponseEntity.status(HttpStatus.OK)
-                .body(travelService.getDetailsByNumber(travelNumber));
+                .body(travelService.getDetailsByNumber(travelNumber, loginUserNumber));
     }
 
     @DeleteMapping("/api/travel/{travelNumber}")
     public ResponseEntity delete(@PathVariable("travelNumber") int travelNumber) {
-        travelService.delete(travelNumber);
+        int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+        logger.info("Travel 삭제 요청 - userId: {}", loginUserNumber);
+
+        travelService.delete(travelNumber, loginUserNumber);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -92,6 +103,7 @@ public class TravelController {
                 .tags(selectedTags)
                 .sortingType(selectedSortingType)
                 .build();
+        log.info("Travel 조회 요청 - search condition: {}", condition.toString());
 
         Page<TravelSearchDto> travels = travelService.search(condition);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -8,12 +8,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelRecommendResponse;
 import swyp.swyp6_team7.travel.service.TravelHomeService;
-
-import java.security.Principal;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -27,9 +25,10 @@ public class TravelHomeController {
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "5") int size
     ) {
+        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
 
         Page<TravelRecentDto> result = travelHomeService
-                .getTravelsSortedByCreatedAt(PageRequest.of(page, size));
+                .getTravelsSortedByCreatedAt(PageRequest.of(page, size), loginUserNumber);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(result);
@@ -38,13 +37,13 @@ public class TravelHomeController {
     @GetMapping("/api/travels/recommend")
     public ResponseEntity<Page<TravelRecommendResponse>> getRecommendTravels(
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "5") int size,
-            Principal principal
+            @RequestParam(name = "size", defaultValue = "5") int size
     ) {
+        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
 
         Page<TravelRecommendResponse> result = travelHomeService
-                .getRecommendTravelsByUser(PageRequest.of(page, size), principal)
-                .map(dto -> new TravelRecommendResponse(dto));
+                .getRecommendTravelsByUser(PageRequest.of(page, size), loginUserNumber)
+                .map(TravelRecommendResponse::new);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(result);

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelSearchController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelSearchController.java
@@ -23,8 +23,7 @@ import java.util.List;
 @RestController
 public class TravelSearchController {
 
-    private static final Logger logger = LoggerFactory.getLogger(TravelController.class);
-
+    private static final Logger logger = LoggerFactory.getLogger(TravelSearchController.class);
     private final TravelSearchService travelSearchService;
 
     @GetMapping("/api/travels/search")
@@ -41,6 +40,7 @@ public class TravelSearchController {
     ) {
 
         Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(page, size))
                 .keyword(keyword)
@@ -54,7 +54,7 @@ public class TravelSearchController {
         logger.info("Travel 조회 요청 - userId: {}, search condition: {}", loginUserNumber, condition.toString());
 
         Page<TravelSearchDto> travels = travelSearchService.search(condition, loginUserNumber);
-        logger.info("Travel 조회 완료 - ");
+        logger.info("Travel 조회 완료 - userId: {}, result: {}", loginUserNumber, travels.getPageable());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(travels);

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelSearchController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelSearchController.java
@@ -1,0 +1,63 @@
+package swyp.swyp6_team7.travel.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
+import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+import swyp.swyp6_team7.travel.service.TravelSearchService;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class TravelSearchController {
+
+    private static final Logger logger = LoggerFactory.getLogger(TravelController.class);
+
+    private final TravelSearchService travelSearchService;
+
+    @GetMapping("/api/travels/search")
+    public ResponseEntity<Page<TravelSearchDto>> search(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "5") int size,
+            @RequestParam(name = "keyword", required = false) String keyword,
+            @RequestParam(name = "location", required = false) List<String> selectedLocation,
+            @RequestParam(name = "gender", required = false) List<String> selectedGender,
+            @RequestParam(name = "person", required = false) List<String> selectedPerson,
+            @RequestParam(name = "period", required = false) List<String> selectedPeriod,
+            @RequestParam(name = "tags", required = false) List<String> selectedTags,
+            @RequestParam(name = "sorting", required = false) String selectedSortingType
+    ) {
+
+        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(page, size))
+                .keyword(keyword)
+                .locationTypes(selectedLocation)
+                .genderTypes(selectedGender)
+                .personTypes(selectedPerson)
+                .periodTypes(selectedPeriod)
+                .tags(selectedTags)
+                .sortingType(selectedSortingType)
+                .build();
+        logger.info("Travel 조회 요청 - userId: {}, search condition: {}", loginUserNumber, condition.toString());
+
+        Page<TravelSearchDto> travels = travelSearchService.search(condition, loginUserNumber);
+        logger.info("Travel 조회 완료 - ");
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(travels);
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -10,12 +10,12 @@ import swyp.swyp6_team7.member.entity.DeletedUsers;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.domain.TravelTag;
-import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -131,7 +131,7 @@ public class Travel {
 
         return tags.stream()
                 .map(tag -> TravelTag.of(this, tag))
-                .toList();
+                .collect(Collectors.toList());
     }
 
     public static Travel create(
@@ -154,16 +154,21 @@ public class Travel {
                 .build();
     }
 
-    public Travel update(TravelUpdateRequest travelUpdate, Location travelLocation) {
-        this.location = travelLocation;
-        this.locationName = travelUpdate.getLocationName();
-        this.title = travelUpdate.getTitle();
-        this.details = travelUpdate.getDetails();
-        this.maxPerson = travelUpdate.getMaxPerson();
-        this.genderType = GenderType.of(travelUpdate.getGenderType());
-        this.dueDate = travelUpdate.getDueDate();
-        this.periodType = PeriodType.of(travelUpdate.getPeriodType());
-        this.status = TravelStatus.convertCompletionToStatus(travelUpdate.getCompletionStatus());
+    public Travel update(
+            Location location, String title, String details, int maxPerson,
+            String genderType, LocalDate dueDate, String periodType, Boolean status,
+            List<TravelTag> tags
+    ) {
+        this.location = location;
+        this.locationName = location.getLocationName();
+        this.title = title;
+        this.details = details;
+        this.maxPerson = maxPerson;
+        this.genderType = GenderType.of(genderType);
+        this.dueDate = dueDate;
+        this.periodType = PeriodType.of(periodType);
+        this.status = TravelStatus.convertCompletionToStatus(status);
+        this.travelTags = tags;
         return this;
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendDto.java
@@ -34,7 +34,7 @@ public class TravelRecommendDto {
     public TravelRecommendDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber
+            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber, boolean bookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelSearchCondition.java
@@ -12,6 +12,7 @@ import swyp.swyp6_team7.travel.util.TravelSearchSortingType;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import swyp.swyp6_team7.location.domain.LocationType;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -57,6 +58,7 @@ public class TravelSearchCondition {
                 .map(this::convertToCityType)
                 .toList();
     }
+
     private LocationType convertToCityType(String locationType) {
         return LocationType.fromString(locationType);
     }
@@ -100,4 +102,17 @@ public class TravelSearchCondition {
                 .toList();
     }
 
+    @Override
+    public String toString() {
+        return "TravelSearchCondition{" +
+                "pageRequest=" + pageRequest +
+                ", keyword='" + keyword + '\'' +
+                ", locationFilter=" + locationFilter +
+                ", genderFilter=" + genderFilter +
+                ", personRangeFilter=" + personRangeFilter +
+                ", periodFilter=" + periodFilter +
+                ", tags=" + tags +
+                ", sortingType=" + sortingType +
+                '}';
+    }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
@@ -8,11 +8,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.location.domain.Location;
-import swyp.swyp6_team7.travel.domain.GenderType;
-import swyp.swyp6_team7.travel.domain.PeriodType;
-import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.domain.TravelStatus;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -55,22 +50,6 @@ public class TravelCreateRequest {
         this.periodType = periodType;
         this.tags = tags;
         this.completionStatus = completionStatus;
-    }
-
-    public Travel toTravelEntity(int userNumber, Location location) {
-        return Travel.builder()
-                .userNumber(userNumber)
-                .location(location)
-                .locationName(location.getLocationName())
-                .title(title)
-                .details(details)
-                .viewCount(0)
-                .maxPerson(maxPerson)
-                .genderType(GenderType.of(genderType))
-                .dueDate(dueDate)
-                .periodType(PeriodType.of(periodType))
-                .status(TravelStatus.convertCompletionToStatus(completionStatus))
-                .build();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
@@ -5,11 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import swyp.swyp6_team7.location.domain.Location;
-import swyp.swyp6_team7.travel.domain.GenderType;
-import swyp.swyp6_team7.travel.domain.PeriodType;
-import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.domain.TravelStatus;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -20,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TravelUpdateRequest {
+
     private String locationName;
     @Size(max = 20)
     private String title;
@@ -35,20 +31,5 @@ public class TravelUpdateRequest {
     private List<String> tags = new ArrayList<>();
     @NotNull
     private Boolean completionStatus;
-
-    public Travel toTravelEntity(int userNumber, Location location) {
-        return Travel.builder()
-                .userNumber(userNumber)
-                .locationName(location.getLocationName())  // location 설정
-                .title(title)
-                .details(details)
-                .viewCount(0)
-                .maxPerson(maxPerson)
-                .genderType(GenderType.of(genderType))
-                .dueDate(dueDate)
-                .periodType(PeriodType.of(periodType))
-                .status(TravelStatus.IN_PROGRESS)
-                .build();
-    }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -206,6 +206,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
     @Override
     public Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber) {
+
+        // 조회 조건에 해당하는 Travel의 Number를 가져온다
         List<Integer> travels = queryFactory
                 .select(travel.number)
                 .from(travel)
@@ -229,8 +231,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .offset(condition.getPageRequest().getOffset())
                 .limit(condition.getPageRequest().getPageSize())
                 .fetch();
-        log.info("search result: " + travels.toString());
 
+        // leftJoin으로 필요한 추가 정보를 가져온다
         List<TravelSearchDto> content = queryFactory
                 .select(travel)
                 .from(travel)
@@ -252,6 +254,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 bookmark.userNumber.eq(loginUserNumber))
                 ));
 
+        // 페이징을 위한 countQuery
         JPAQuery<Long> countQuery = queryFactory
                 .select(travel.number.countDistinct())
                 .from(travel)

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import swyp.swyp6_team7.member.entity.DeletedUsers;
 import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.time.LocalDateTime;
@@ -13,10 +12,11 @@ import java.util.Optional;
 
 public interface TravelRepository extends JpaRepository<Travel, Integer>, TravelCustomRepository {
     Optional<Travel> findByNumber(Integer integer);
+
     List<Travel> findByUserNumber(int userNumber);
+
     @Query("SELECT t FROM Travel t JOIN FETCH t.deletedUser u WHERE u.userNumber = :deletedUserNumber")
     List<Travel> findByDeletedUserNumber(@Param("deletedUserNumber") Integer deletedUserNumber);
-
 
     @Query("SELECT t.enrollmentsLastViewedAt FROM Travel t WHERE t.number = :travelNumber")
     LocalDateTime getEnrollmentsLastViewedAtByNumber(@Param("travelNumber") int travelNumber);
@@ -25,10 +25,8 @@ public interface TravelRepository extends JpaRepository<Travel, Integer>, Travel
     @Query("UPDATE Travel t SET t.enrollmentsLastViewedAt = :lastViewedAt WHERE t.number = :travelNumber")
     void updateEnrollmentsLastViewedAtByNumber(@Param("travelNumber") int travelNumber, @Param("lastViewedAt") LocalDateTime lastViewedAt);
 
-
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Travel t SET t.viewCount = t.viewCount + 1 WHERE t.number = :travelNumber")
     void updateViewCountPlusOneByTravelNumber(@Param("travelNumber") int travelNumber);
-
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelHomeService.java
@@ -14,7 +14,6 @@ import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 import swyp.swyp6_team7.travel.util.TravelRecommendComparator;
 
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,16 +27,14 @@ public class TravelHomeService {
     private final TravelRepository travelRepository;
     private final UserTagPreferenceRepository userTagPreferenceRepository;
 
-    public Page<TravelRecentDto> getTravelsSortedByCreatedAt(PageRequest pageRequest) {
-        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
+    public Page<TravelRecentDto> getTravelsSortedByCreatedAt(PageRequest pageRequest, Integer loginUserNumber) {
         return travelRepository.findAllSortedByCreatedAt(pageRequest, loginUserNumber);
     }
 
-    public Page<TravelRecommendDto> getRecommendTravelsByUser(PageRequest pageRequest, Principal principal) {
+    public Page<TravelRecommendDto> getRecommendTravelsByUser(PageRequest pageRequest, Integer loginUserNumber) {
 
-        Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
         List<String> preferredTags = userTagPreferenceRepository.findPreferenceTagsByUserNumber(loginUserNumber);
-        //log.info("preferredTags: " + preferredTags);
+        log.info("TravelHomeService recommend - userId: {}, preferredTags: {}", loginUserNumber, preferredTags);
 
         Page<TravelRecommendDto> result = travelRepository.findAllByPreferredTags(pageRequest, loginUserNumber, preferredTags);
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
@@ -3,14 +3,16 @@ package swyp.swyp6_team7.travel.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 @Slf4j
 @RequiredArgsConstructor
-@RestController
+@Transactional(readOnly = true)
+@Service
 public class TravelSearchService {
 
     private final TravelRepository travelRepository;

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
@@ -1,0 +1,23 @@
+package swyp.swyp6_team7.travel.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class TravelSearchService {
+
+    private final TravelRepository travelRepository;
+
+    public Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber) {
+        Page<TravelSearchDto> result = travelRepository.search(condition, loginUserNumber);
+        return result;
+    }
+
+}

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -36,6 +36,8 @@ import java.util.List;
 @Service
 public class TravelService {
 
+    private final static String DEFAULT_PROFILE_IMAGE_URL = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
+
     private final TravelTagService travelTagService;
     private final CommentService commentService;
     private final TravelRepository travelRepository;
@@ -74,7 +76,7 @@ public class TravelService {
 
     public TravelDetailResponse getDetailsByNumber(int travelNumber, int requestUserNumber) {
         Travel travel = travelRepository.findByNumber(travelNumber)
-                .orElseThrow(() -> new IllegalArgumentException("Travel not found: " + travelNumber));
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber));
 
         if (travel.getStatus() == TravelStatus.DRAFT) {
             if (travel.getUserNumber() != requestUserNumber) {
@@ -90,7 +92,7 @@ public class TravelService {
 
         //주최자 프로필 이미지(만약 못찾을 경우 default 이미지 url)
         String hostProfileImageUrl = imageRepository.findUrlByRelatedUserNumber(travelDetail.getHostNumber())
-                .orElse("https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png");
+                .orElse(DEFAULT_PROFILE_IMAGE_URL);
 
         //enrollment 개수
         int enrollmentCount = enrollmentRepository.countByTravelNumber(travelNumber);
@@ -121,7 +123,7 @@ public class TravelService {
     @Transactional
     public Travel update(int travelNumber, TravelUpdateRequest request, int requestUserNumber) {
         Travel travel = travelRepository.findByNumber(travelNumber)
-                .orElseThrow(() -> new IllegalArgumentException("travel not found: " + travelNumber));
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber));
 
         if (travel.getUserNumber() != requestUserNumber) {
             log.warn("여행 수정 권한이 없습니다. - travelNumber: {}, requestUser: {}", travelNumber, requestUserNumber);
@@ -140,7 +142,7 @@ public class TravelService {
     @Transactional
     public void delete(int travelNumber, int requestUserNumber) {
         Travel travel = travelRepository.findByNumber(travelNumber)
-                .orElseThrow(() -> new IllegalArgumentException("travel not found: " + travelNumber));
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber));
 
         if (travel.getUserNumber() != requestUserNumber) {
             log.warn("여행 삭제 권한이 없습니다. - travelNumber: {}, requestUser: {}", travelNumber, requestUserNumber);

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -14,6 +14,10 @@ import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.domain.TravelTag;
+import swyp.swyp6_team7.tag.repository.TravelTagRepository;
+import swyp.swyp6_team7.tag.service.TagService;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
@@ -35,6 +39,7 @@ public class TravelService {
     private final static String DEFAULT_PROFILE_IMAGE_URL = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
 
     private final TravelTagService travelTagService;
+    private final TagService tagService;
     private final CommentService commentService;
     private final TravelRepository travelRepository;
     private final EnrollmentRepository enrollmentRepository;
@@ -47,13 +52,19 @@ public class TravelService {
     public Travel create(TravelCreateRequest request, int loginUserNumber) {
 
         Location location = getLocation(request.getLocationName());
+        List<Tag> tags = getTags(request.getTags());
 
-        Travel savedTravel = travelRepository.save(request.toTravelEntity(loginUserNumber, location));
-        List<String> tags = travelTagService.create(savedTravel, request.getTags()).stream()
-                .map(tag -> tag.getName())
+        Travel travel = Travel.create(loginUserNumber, location,
+                request.getTitle(), request.getDetails(), request.getMaxPerson(),
+                request.getGenderType(), request.getDueDate(), request.getPeriodType(), tags);
+
+        return travelRepository.save(travel);
+    }
+
+    private List<Tag> getTags(List<String> tagNames) {
+        return tagNames.stream()
+                .map(name -> tagService.findByName(name))
                 .toList();
-
-        return savedTravel;
     }
 
     private Location getLocation(String locationName) {

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -2,7 +2,6 @@ package swyp.swyp6_team7.travel.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
@@ -15,16 +14,13 @@ import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
-import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
-import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
-import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDateTime;
@@ -157,12 +153,6 @@ public class TravelService {
         for (Comment comment : comments) {
             commentService.delete(comment.getCommentNumber(), travel.getUserNumber());
         }
-    }
-
-    public Page<TravelSearchDto> search(TravelSearchCondition condition) {
-        Integer requestUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
-        Page<TravelSearchDto> result = travelRepository.search(condition, requestUserNumber);
-        return result;
     }
 
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -15,8 +15,6 @@ import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
 import swyp.swyp6_team7.tag.domain.Tag;
-import swyp.swyp6_team7.tag.domain.TravelTag;
-import swyp.swyp6_team7.tag.repository.TravelTagRepository;
 import swyp.swyp6_team7.tag.service.TagService;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.Travel;

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -16,7 +16,6 @@ import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
-import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.service.MemberService;
 import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.tag.service.TravelTagService;
@@ -39,20 +38,19 @@ import java.util.List;
 @Service
 public class TravelService {
 
+    private final TravelTagService travelTagService;
+    private final MemberService memberService;
+    private final CommentService commentService;
     private final TravelRepository travelRepository;
     private final EnrollmentRepository enrollmentRepository;
     private final BookmarkRepository bookmarkRepository;
     private final ImageRepository imageRepository;
-    private final TravelTagService travelTagService;
-    private final MemberService memberService;
     private final LocationRepository locationRepository;
     private final CommentRepository commentRepository;
-    private final CommentService commentService;
 
     @Transactional
-    public Travel create(TravelCreateRequest request, String email) {
+    public Travel create(TravelCreateRequest request, int loginUserNumber) {
 
-        Users user = memberService.findByEmail(email);
         // Location 정보가 없으면 새로운 Location 추가 (locationType은 UNKNOWN으로 설정)
         Location location = locationRepository.findByLocationName(request.getLocationName())
                 .orElseGet(() -> {
@@ -63,7 +61,8 @@ public class TravelService {
                     return locationRepository.save(newLocation);
                 });
 
-        Travel savedTravel = travelRepository.save(request.toTravelEntity(user.getUserNumber(), location));
+        Travel savedTravel = travelRepository.save(request.toTravelEntity(loginUserNumber, location));
+        log.info("savedTravel = " + savedTravel.toString());
         List<String> tags = travelTagService.create(savedTravel, request.getTags()).stream()
                 .map(tag -> tag.getName())
                 .toList();

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -15,6 +15,7 @@ import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
 import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.domain.TravelTag;
 import swyp.swyp6_team7.tag.service.TagService;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.Travel;
@@ -34,6 +35,7 @@ import java.util.List;
 @Service
 public class TravelService {
 
+    public static final int TRAVEL_TAG_MAX_COUNT = 5;
     private final static String DEFAULT_PROFILE_IMAGE_URL = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
 
     private final TravelTagService travelTagService;
@@ -61,6 +63,7 @@ public class TravelService {
 
     private List<Tag> getTags(List<String> tagNames) {
         return tagNames.stream()
+                .distinct().limit(TRAVEL_TAG_MAX_COUNT)
                 .map(name -> tagService.findByName(name))
                 .toList();
     }
@@ -137,9 +140,17 @@ public class TravelService {
 
         Location location = getLocation(request.getLocationName());
 
-        Travel updatedTravel = travel.update(request, location);
-        //List<String> updatedTags = travelTagService.update(updatedTravel, request.getTags());
-        travelTagService.update(updatedTravel, request.getTags());
+        List<String> requestTagsName = request.getTags().stream()
+                .distinct().limit(TRAVEL_TAG_MAX_COUNT)
+                .toList();
+        List<TravelTag> travelTags = travelTagService.update(travel, requestTagsName);
+
+        Travel updatedTravel = travel.update(
+                location, request.getTitle(), request.getDetails(), request.getMaxPerson(),
+                request.getGenderType(), request.getDueDate(), request.getPeriodType(), request.getCompletionStatus(),
+                travelTags
+        );
+
         return updatedTravel;
     }
 

--- a/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
@@ -1,6 +1,7 @@
 package swyp.swyp6_team7.companion.service;
 
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,12 @@ class CompanionServiceTest {
                 .build());
     }
 
+    @AfterEach
+    void tearDown() {
+        companionRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+    }
 
     @DisplayName("findCompanionInfo: 특정 여행의 companion 정보를 가져올 수 있다")
     @Test

--- a/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
@@ -82,6 +82,7 @@ class CompanionServiceTest {
         companionRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         travelRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
     }
 
     @DisplayName("findCompanionInfo: 특정 여행의 companion 정보를 가져올 수 있다")

--- a/src/test/java/swyp/swyp6_team7/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/controller/EnrollmentControllerTest.java
@@ -1,6 +1,7 @@
 package swyp.swyp6_team7.enrollment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,7 +89,7 @@ class EnrollmentControllerTest {
 
     @BeforeEach
     void setSecurityContext() {
-        userRepository.deleteAll();
+        //userRepository.deleteAll();
         user = userRepository.save(Users.builder()
                 .userEmail("abc@test.com")
                 .userPw("1234")
@@ -104,13 +105,20 @@ class EnrollmentControllerTest {
         context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
     }
 
-    @BeforeEach
-    void setUp(){
-        enrollmentRepository.deleteAll();
-        travelRepository.deleteAll();
-        locationRepository.deleteAll();
-    }
+//    @BeforeEach
+//    void setUp(){
+//        enrollmentRepository.deleteAll();
+//        travelRepository.deleteAll();
+//        locationRepository.deleteAll();
+//    }
 
+    @AfterEach
+    void tearDown() {
+        enrollmentRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
 
     @DisplayName("create: 사용자는 여행 신청을 생성할 수 있다")
     @Test

--- a/src/test/java/swyp/swyp6_team7/tag/service/TagServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/tag/service/TagServiceTest.java
@@ -1,0 +1,61 @@
+package swyp.swyp6_team7.tag.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.repository.TagRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TagServiceTest {
+
+    @Autowired
+    private TagService tagService;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @AfterEach
+    void tearDown() {
+        tagRepository.deleteAllInBatch();
+    }
+
+
+    @DisplayName("findByName: 태그 이름이 주어질 때, 태그를 가져올 수 있다.")
+    @Test
+    void findByName() {
+        // given
+        String tagName = "태그 이름";
+        tagRepository.save(Tag.of(tagName));
+
+        // when
+        Tag tag = tagService.findByName(tagName);
+
+        // then
+        assertThat(tagRepository.findAll()).hasSize(1)
+                .extracting("name")
+                .contains("태그 이름");
+        assertThat(tag.getName()).isEqualTo("태그 이름");
+    }
+
+    @DisplayName("findByName: 존재하지 않는 태그인 경우 새로운 Tag를 생성한다.")
+    @Test
+    void findByNameWithCreateNewTag() {
+        // given
+        String newTagName = "새로운 태그";
+
+        // when
+        Tag tag = tagService.findByName(newTagName);
+
+        // then
+        assertThat(tagRepository.findAll()).hasSize(1)
+                .extracting("name")
+                .contains("새로운 태그");
+        assertThat(tag.getName()).isEqualTo("새로운 태그");
+    }
+
+}

--- a/src/test/java/swyp/swyp6_team7/tag/service/TravelTagServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/tag/service/TravelTagServiceTest.java
@@ -1,0 +1,114 @@
+package swyp.swyp6_team7.tag.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import swyp.swyp6_team7.location.domain.Location;
+import swyp.swyp6_team7.location.domain.LocationType;
+import swyp.swyp6_team7.location.repository.LocationRepository;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.domain.TravelTag;
+import swyp.swyp6_team7.tag.repository.TagRepository;
+import swyp.swyp6_team7.tag.repository.TravelTagRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TravelTagServiceTest {
+
+    @Autowired
+    private TravelTagService travelTagService;
+
+    @Autowired
+    private TagService tagService;
+
+    @Autowired
+    private TravelTagRepository travelTagRepository;
+
+    @Autowired
+    private TravelRepository travelRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @AfterEach
+    void tearDown() {
+        travelTagRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        tagRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("update: 여행과 태그 이름 리스트가 주어지면, 변경된 TravelTag 리스트를 얻을 수 있다.")
+    @Test
+    void update() {
+        // given
+        Travel travel = travelRepository.save(createTravel(List.of()));
+        List<String> newTags = List.of("쇼핑", "자연");
+
+        // when
+        List<TravelTag> travelTags = travelTagService.update(travel, newTags);
+
+        // then
+        assertThat(tagRepository.findAll()).hasSize(2);
+        assertThat(travelTagRepository.findAll()).hasSize(0);
+
+        assertThat(travelTags).hasSize(2)
+                .map(travelTag -> travelTag.getTag())
+                .extracting("name")
+                .containsExactlyInAnyOrder("자연", "쇼핑");
+    }
+
+    @DisplayName("update: 여행과 태그 이름 리스트가 주어질 때, 더이상 필요없는 TravelTag는 삭제된다.")
+    @Test
+    void updateWithNoLongerNeedTravelTag() {
+        // given
+        Tag tag = tagRepository.save(Tag.of("먹방"));
+        Travel travel = travelRepository.save(createTravel(Arrays.asList(tag)));
+
+        List<String> newTags = List.of("쇼핑", "자연");
+
+        // when
+        List<TravelTag> travelTags = travelTagService.update(travel, newTags);
+
+        // then
+        assertThat(tagRepository.findAll()).hasSize(3);
+        assertThat(travelTagRepository.findAll()).hasSize(0);
+
+        assertThat(travelTags).hasSize(2)
+                .map(travelTag -> travelTag.getTag())
+                .extracting("name")
+                .containsExactlyInAnyOrder("자연", "쇼핑");
+    }
+
+
+    private Travel createTravel(List<Tag> tags) {
+        Location location = locationRepository.save(Location.builder()
+                .locationName("여행지명")
+                .locationType(LocationType.DOMESTIC)
+                .build());
+
+        return Travel.builder()
+                .userNumber(1)
+                .location(location)
+                .viewCount(0)
+                .genderType(GenderType.MIXED)
+                .periodType(PeriodType.ONE_WEEK)
+                .status(TravelStatus.IN_PROGRESS)
+                .tags(tags)
+                .build();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -31,6 +31,7 @@ import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
@@ -110,13 +111,14 @@ class TravelControllerTest {
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
 
+        LocalDate dueDate = LocalDate.now().plusDays(1);
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("Seoul")
                 .title("여행 제목")
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType(GenderType.MIXED.toString())
-                .dueDate(LocalDate.of(2024, 11, 4))
+                .dueDate(dueDate)
                 .periodType(PeriodType.ONE_WEEK.toString())
                 .tags(List.of())
                 .completionStatus(true)
@@ -133,7 +135,7 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.location").value("Seoul"))
                 .andExpect(jsonPath("$.title").value("여행 제목"))
                 .andExpect(jsonPath("$.details").value("여행 내용"))
-                .andExpect(jsonPath("$.dueDate").value("2024-11-04"))
+                .andExpect(jsonPath("$.dueDate").value(dueDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
                 .andExpect(jsonPath("$.postStatus").value(TravelStatus.IN_PROGRESS.toString()));
     }
 

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelEnrollmentControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelEnrollmentControllerTest.java
@@ -1,6 +1,7 @@
 package swyp.swyp6_team7.travel.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,6 +115,12 @@ class TravelEnrollmentControllerTest {
         );
     }
 
+    @AfterEach
+    void tearDown() {
+        enrollmentRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
 
     @DisplayName("findElements: 주최자는 특정 여행에 대한 참가 신청서 목록을 조회할 수 있다")
     @Test

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -161,26 +161,6 @@ class TravelCustomRepositoryImplTest {
                         tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3)
                 );
     }
-//
-//    @DisplayName("findEnrollmentsByUserNumber: 사용자의 신청한 여행 목록 조회")
-//    @Test
-//    public void findEnrollmentsByUserNumber_ShouldReturnListOfEnrollments() {
-//        // given
-//        int userNumber = 1;
-//
-//        // when
-//        List<Tuple> results = enrollmentCustomRepository.findEnrollmentsByUserNumber(userNumber);
-//
-//        // then
-//        assertThat(results).isNotNull();
-//        assertThat(results.size()).isGreaterThan(0);
-//        Tuple tuple = results.get(0);
-//        assertThat(tuple.get(0, Long.class)).isNotNull(); // Enrollment number
-//        assertThat(tuple.get(1, Integer.class)).isNotNull(); // Travel number
-//
-//        System.out.println("Enrollment Number: " + tuple.get(0, Long.class));
-//        System.out.println("Travel Number: " + tuple.get(1, Integer.class));
-//    }
 
     @DisplayName("search: keyword가 포함된 여행을 가져올 수 있다.")
     @Test

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -124,9 +124,9 @@ class TravelCustomRepositoryImplTest {
         travelTagRepository.deleteAllInBatch();
         travelRepository.deleteAllInBatch();
         tagRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
         enrollmentRepository.deleteAllInBatch();
         locationRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
     }
 
     @DisplayName("getDetailsByNumber: 여행콘텐츠 식별자로 디테일 정보를 가져온다")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -1,21 +1,15 @@
 package swyp.swyp6_team7.travel.repository;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.annotation.DirtiesContext;
+import swyp.swyp6_team7.bookmark.entity.Bookmark;
+import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
 import swyp.swyp6_team7.config.DataConfig;
-import swyp.swyp6_team7.enrollment.domain.Enrollment;
-import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
-import swyp.swyp6_team7.enrollment.repository.EnrollmentCustomRepository;
-import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
@@ -25,7 +19,6 @@ import swyp.swyp6_team7.member.entity.UserStatus;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
 import swyp.swyp6_team7.tag.domain.Tag;
-import swyp.swyp6_team7.tag.domain.TravelTag;
 import swyp.swyp6_team7.tag.repository.TagRepository;
 import swyp.swyp6_team7.tag.repository.TravelTagRepository;
 import swyp.swyp6_team7.travel.domain.GenderType;
@@ -41,13 +34,12 @@ import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-
-import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import static org.assertj.core.api.Assertions.tuple;
+import static swyp.swyp6_team7.travel.domain.TravelStatus.*;
 
 @Import(DataConfig.class)
 @DataJpaTest
@@ -62,800 +54,114 @@ class TravelCustomRepositoryImplTest {
     @Autowired
     private UserRepository userRepository;
     @Autowired
-    @Qualifier("enrollmentCustomRepositoryImpl")
-    private EnrollmentCustomRepository enrollmentCustomRepository;
-    @Autowired
-    private EnrollmentRepository enrollmentRepository;
-    @Autowired
     private LocationRepository locationRepository;
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+//    @Autowired
+//    @Qualifier("enrollmentCustomRepositoryImpl")
+//    private EnrollmentCustomRepository enrollmentCustomRepository;
+//    @Autowired
+//    private EnrollmentRepository enrollmentRepository;
 
-    Users user;
 
-    @BeforeEach
-    void setUp() {
-
-        travelTagRepository.deleteAll();
-        travelRepository.deleteAll();
-        tagRepository.deleteAll();
-        userRepository.deleteAll();
-        enrollmentRepository.deleteAll();
-
-        Location travelLocation = Location.builder()
-                .locationName("Seoul")
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel savedTravel = travelRepository.save(Travel.builder()
-                .title("기본 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-
-        user = userRepository.save(Users.builder()
-                .userNumber(1)
-                .userEmail("testuser@naver.com")
-                .userPw("password")
-                .userName("테스트 사용자")
-                .userGender(Gender.M)
-                .userAgeGroup(AgeGroup.TWENTY)
-                .userRegDate(LocalDateTime.now())
-                .userStatus(UserStatus.ABLE)
-                .build());
-
-        int travelNumber = savedTravel.getNumber();
-
-        enrollmentRepository.save(Enrollment.builder()
-                .userNumber(user.getUserNumber())
-                .travelNumber(travelNumber)
-                .createdAt(LocalDateTime.now())
-                .message("참가 신청 메시지")
-                .status(EnrollmentStatus.ACCEPTED)
-                .build());
-    }
-
-    @AfterEach
-    void tearDown() {
-        // 데이터 삭제
-        travelTagRepository.deleteAllInBatch();
-        travelRepository.deleteAllInBatch();
-        tagRepository.deleteAllInBatch();
-        enrollmentRepository.deleteAllInBatch();
-        locationRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
-
-    @DisplayName("getDetailsByNumber: 여행콘텐츠 식별자로 디테일 정보를 가져온다")
+    @DisplayName("getDetailsByNumber: 여행 번호가 주어지면 여행의 디테일 정보를 가져올 수 있다.")
     @Test
     public void getDetailsByNumber() {
         // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Users user = userRepository.save(Users.builder()
-                .userEmail("test@naver.com")
-                .userPw("1234")
-                .userName("모잉")
-                .userGender(Gender.M)
-                .userAgeGroup(AgeGroup.TWENTY)
-                .userRegDate(LocalDateTime.now())
-                .userStatus(UserStatus.ABLE)
-                .build());
-        Tag tag1 = tagRepository.save(Tag.of("한국"));
-        Tag tag2 = tagRepository.save(Tag.of("투어"));
-        Travel travel = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(user.getUserNumber())
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        travelTagRepository.save(TravelTag.of(travel, tag1));
-        travelTagRepository.save(TravelTag.of(travel, tag2));
+        Users host = userRepository.save(createHostUser());
+
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        List<Tag> tags = tagRepository.saveAll(Arrays.asList(tag1, tag2));
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                host.getUserNumber(), location, "여행", 0, 2, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, tags);
+        travelRepository.save(travel1);
 
         // when
-        TravelDetailDto details = travelRepository.getDetailsByNumber(travel.getNumber(), user.getUserNumber());
+        TravelDetailDto details = travelRepository.getDetailsByNumber(travel1.getNumber(), 1);
 
         // then
-        System.out.println(details.toString());
-        assertThat(details.getTravel().getTitle()).isEqualTo("추가 테스트 데이터1");
-        assertThat(details.getHostNumber()).isEqualTo(user.getUserNumber());
-        assertThat(details.getHostName()).isEqualTo("모잉");
-        assertThat(details.getTags().size()).isEqualTo(2);
+        assertThat(details)
+                .extracting("travel", "hostNumber", "hostName", "hostAgeGroup", "companionCount", "tags", "bookmarked")
+                .contains(travel1, host.getUserNumber(), "주최자 이름", "10대", 0, List.of("쇼핑", "자연"), false);
     }
 
-    @DisplayName("findAll: 여행 콘텐츠를 DTO로 만들어 최신순으로 정렬해 반환한다")
+    @DisplayName("findAll: 여행을 최신순으로 가져올 수 있다.")
     @Test
     public void findAllSortedByCreatedAt() {
         // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel = Travel.builder()
-                .title("추가 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .location(savedLocation)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now().plusDays(1))
-                .status(TravelStatus.IN_PROGRESS)
-                .build();
-        travelRepository.save(travel);
-        for (int i = 0; i < 5; i++) {
-            Tag tag = tagRepository.save(Tag.of("태그" + i));
-            travelTagRepository.save(TravelTag.of(travel, tag));
-        }
+        Users host = userRepository.save(createHostUser());
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                host.getUserNumber(), location, "여행", 0, 2, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                host.getUserNumber(), location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2));
 
         // when
         Page<TravelRecentDto> results = travelRepository
                 .findAllSortedByCreatedAt(PageRequest.of(0, 5), 1);
 
         // then
-        for (TravelRecentDto result : results) {
-            System.out.println(result.toString());
-        }
-        assertThat(results.getContent().size()).isEqualTo(2);
-        assertThat(results.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터");
-        assertThat(results.getContent().get(0).getTags().size()).isEqualTo(5);
+        assertThat(results.getContent()).hasSize(2)
+                .extracting("travelNumber", "title", "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue", "bookmarked")
+                .containsExactly(
+                        tuple(travel2.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 0, dueDate, false),
+                        tuple(travel1.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 2, dueDate, false)
+                );
     }
 
-    @DisplayName("findAll: 최신순으로 정렬해 반환할 때 데이터가 없을 경우에도 오류가 나지 않는다")
-    @Test
-    public void findAllSortedByCreatedAtNoData() {
-        // given
-        travelRepository.deleteAll();
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-
-        // when
-        Page<TravelRecentDto> results = travelRepository
-                .findAllSortedByCreatedAt(PageRequest.of(0, 5), 1);
-
-        // then
-        for (TravelRecentDto result : results) {
-            System.out.println(result.toString());
-        }
-        assertThat(results.getContent().size()).isEqualTo(0);
-    }
-
-    @DisplayName("findAllByPreferredTags: 사용자의 선호 태그와 콘텐츠 태그의 중복이 많은 순서대로 콘텐츠를 정렬한다")
+    @DisplayName("findAllByPreferredTags: 사용자의 선호 태그와 콘텐츠 태그의 중복 태그 개수를 여행과 함께 가져올 수 있다.")
     @Test
     public void findAllByPreferredTags() {
         // given
-        //travelRepository.deleteAll();
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Tag tag1 = tagRepository.save(Tag.of("한국"));
-        Tag tag2 = tagRepository.save(Tag.of("투어"));
-        Tag tag3 = tagRepository.save(Tag.of("도시"));
-        Tag tag4 = tagRepository.save(Tag.of("여유"));
-        List<String> preferredTags = new ArrayList<>(List.of("한국", "투어", "도시"));
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        Tag tag3 = Tag.of("먹방");
+        Tag tag4 = Tag.of("즉흥");
+        tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
 
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
+        Travel travel4 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
+        travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
 
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .dueDate(LocalDate.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국 -> 1개
-        travelTagRepository.save(TravelTag.of(travel2, tag1));
-
-        Travel travel3 = travelRepository.save(Travel.builder()
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국, 투어 -> 2개
-        travelTagRepository.save(TravelTag.of(travel3, tag1));
-        travelTagRepository.save(TravelTag.of(travel3, tag2));
-
-        Travel travel4 = travelRepository.save(Travel.builder()
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .dueDate(LocalDate.now().plusDays(1))
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국, 여유 -> 1개
-        travelTagRepository.save(TravelTag.of(travel4, tag1));
-        travelTagRepository.save(TravelTag.of(travel4, tag4));
-
-        Travel travel5 = travelRepository.save(Travel.builder()
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국, 투어, 도시 -> 3개
-        travelTagRepository.save(TravelTag.of(travel5, tag1));
-        travelTagRepository.save(TravelTag.of(travel5, tag2));
-        travelTagRepository.save(TravelTag.of(travel5, tag3));
+        List<String> preferredTags = Arrays.asList("쇼핑", "자연", "먹방");
 
         // when
         Page<TravelRecommendDto> result = travelRepository
-                .findAllByPreferredTags(PageRequest.of(0, 5), user.getUserNumber(), preferredTags);
+                .findAllByPreferredTags(PageRequest.of(0, 5), 1, preferredTags);
 
         // then
-        assertThat(result.getContent().size()).isEqualTo(5); //0, 1, 2, 1, 3
-        List<Integer> preferredNum = result.stream()
-                .map(dto -> dto.getPreferredNumber())
-                .toList();
-        assertThat(Collections.frequency(preferredNum, 0)).isEqualTo(1);
-        assertThat(Collections.frequency(preferredNum, 1)).isEqualTo(2);
-        assertThat(Collections.frequency(preferredNum, 2)).isEqualTo(1);
-        assertThat(Collections.frequency(preferredNum, 3)).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(4)
+                .extracting("travelNumber", "tags", "preferredNumber")
+                .containsExactlyInAnyOrder(
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑"), 1),
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2),
+                        tuple(travel3.getNumber(), Arrays.asList("쇼핑", "즉흥"), 1),
+                        tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3)
+                );
     }
-
-    @DisplayName("search: 제목에 keyword가 포함된 데이터를 찾을 수 있다")
-    @Test
-    public void searchWithKeyword() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel = Travel.builder()
-                .title("추가 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build();
-        travelRepository.save(travel);
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword("추가")
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(1);
-        assertThat(results.getContent().size()).isEqualTo(1);
-    }
-
-    @DisplayName("search: 제목과 장소에 keyword가 포함된 데이터를 찾을 수 있다")
-    @Test
-    public void searchWithKeywordThroughTitleAndLocation() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("영국" + System.currentTimeMillis())
-                .locationType(LocationType.INTERNATIONAL)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .locationName("영국" + System.currentTimeMillis())
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .title("영국 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword("영국")
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(2);
-        assertThat(results.getContent().size()).isEqualTo(2);
-    }
-
-    @DisplayName("search: 키워드가 주어지지 않을 경우 가능한 모든 콘텐츠를 전달")
-    @Test
-    public void searchWithoutKeyword() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel = Travel.builder()
-                .title("추가 테스트 데이터")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build();
-        travelRepository.save(travel);
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                //.keyword("")
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(2);
-        assertThat(results.getContent().size()).isEqualTo(2);
-    }
-
-    @DisplayName("search: 콘텐츠의 상태가 DELETED, DRAFT일 경우 제외하고 가져온다")
-    @Test
-    public void searchOnlyActivated() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel deletedTravel = Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.DELETED)
-                .location(savedLocation)
-                .build();
-        travelRepository.save(deletedTravel);
-        Travel draftTravel = Travel.builder()
-                .title("추가 테스트 데이터2")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.DELETED)
-                .location(savedLocation)
-                .build();
-        travelRepository.save(draftTravel);
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword("데이터")
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(1);
-        assertThat(results.getContent().size()).isEqualTo(1);
-    }
-
-    @DisplayName("search: 페이징을 이용해 콘텐츠를 가져올 수 있다")
-    @Test
-    public void searchWithPaging() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        for (int i = 0; i < 6; i++) {
-            travelRepository.save(Travel.builder()
-                    .title("추가 테스트 데이터")
-                    .userNumber(1)
-                    .viewCount(0)
-                    .periodType(PeriodType.NONE)
-                    .genderType(GenderType.NONE)
-                    .createdAt(LocalDateTime.now())
-                    .status(TravelStatus.IN_PROGRESS)
-                    .location(savedLocation)
-                    .build());
-        }
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .keyword("추가")
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getTotalElements()).isEqualTo(6);
-        assertThat(result.getContent().size()).isEqualTo(5);
-    }
-
-    @DisplayName("search: 주어지는 태그가 달린 콘텐츠를 가져온다")
-    @Test
-    public void searchWithTags() {
-        // given
-        Tag tag = tagRepository.save(Tag.of("테스트"));
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        for (int i = 0; i < 6; i++) {
-            Travel travel = travelRepository.save(Travel.builder()
-                    .title("추가 테스트 데이터" + i)
-                    .userNumber(1)
-                    .viewCount(0)
-                    .periodType(PeriodType.NONE)
-                    .genderType(GenderType.NONE)
-                    .createdAt(LocalDateTime.now())
-                    .status(TravelStatus.IN_PROGRESS)
-                    .location(savedLocation)
-                    .build());
-            travelTagRepository.save(TravelTag.of(travel, tag));
-        }
-
-        List<String> tags = new ArrayList<>();
-        tags.add("테스트");
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .tags(tags)
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then;
-        assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getTotalElements()).isEqualTo(6);
-        assertThat(result.getContent().size()).isEqualTo(5);
-    }
-
-    @DisplayName("search: 여러 개의 태그가 주어졌을 때, 모든 태그를 가진 콘텐츠만 가져온다")
-    @Test
-    public void searchWithMultipleTags() {
-        // given
-        Tag tag1 = tagRepository.save(Tag.of("한국"));
-        Tag tag2 = tagRepository.save(Tag.of("투어"));
-        Tag tag3 = tagRepository.save(Tag.of("도시"));
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-
-        Travel travel1 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국, 도시
-        travelTagRepository.save(TravelTag.of(travel1, tag1));
-        travelTagRepository.save(TravelTag.of(travel1, tag3));
-
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터2")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        //tags: 한국, 투어
-        travelTagRepository.save(TravelTag.of(travel2, tag1));
-        travelTagRepository.save(TravelTag.of(travel2, tag2));
-
-        List<String> tags = new ArrayList<>();
-        tags.add("한국");
-        tags.add("투어");
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .tags(tags)
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent().size()).isEqualTo(1);
-        assertThat(result.getContent().get(0).getTitle()).isEqualTo("추가 테스트 데이터2");
-    }
-
-    @DisplayName("search: 주어지는 젠더 타입에 알맞은 콘텐츠를 가져올 수 있다")
-    @Test
-    public void searchWithGenderFilter() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel1 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.WOMAN_ONLY)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터2")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.MIXED)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel3 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터3")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.MAN_ONLY)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .genderTypes(new ArrayList<>(List.of(GenderType.WOMAN_ONLY.toString(), GenderType.MIXED.toString())))
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(result.getContent().size()).isEqualTo(2);
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
-    }
-
-    @DisplayName("search: 주어지는 기간 타입에 알맞은 콘텐츠를 가져올 수 있다")
-    @Test
-    public void searchWithPeriodFilter() {
-        // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel1 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.MORE_THAN_MONTH)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터2")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.THREE_WEEKS)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel3 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터3")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.TWO_WEEKS)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .periodTypes(new ArrayList<>(List.of(
-                        PeriodType.MORE_THAN_MONTH.toString(),
-                        PeriodType.THREE_WEEKS.toString()))
-                )
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(result.getContent().size()).isEqualTo(2);
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel2.getNumber());
-    }
-
-    @DisplayName("search: 주어지는 인원 타입에 알맞은 콘텐츠를 가져올 수 있다")
-    @Test
-    public void searchWithPersonRangeFilter() {
-        // given
-        travelRepository.deleteAll();
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        Travel travel1 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터1")
-                .userNumber(1)
-                .viewCount(0)
-                .maxPerson(1)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel2 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터2")
-                .userNumber(1)
-                .viewCount(0)
-                .maxPerson(4)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        Travel travel3 = travelRepository.save(Travel.builder()
-                .title("추가 테스트 데이터3")
-                .userNumber(1)
-                .viewCount(0)
-                .maxPerson(6)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedLocation)
-                .build());
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .personTypes(List.of("2명", "5명 이상"))
-                .build();
-
-        // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, user.getUserNumber());
-
-        // then
-        assertThat(result.getContent().size()).isEqualTo(2);
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel1.getNumber());
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).doesNotContain(travel2.getNumber());
-        assertThat(result.getContent().stream().map(c -> c.getTravelNumber())).contains(travel3.getNumber());
-    }
-
-  /*  @DisplayName("search: 장소 필터링을 통해 국내 또는 해외 여행을 검색할 수 있다")
-    @Test
-    @DirtiesContext
-    public void searchWithLocationFilter() {
-        // given
-        Location domesticLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location internationalLocation = Location.builder()
-                .locationName("London"+System.currentTimeMillis())
-                .locationType(LocationType.INTERNATIONAL)
-                .build();
-
-        Location savedDomesticLocation = locationRepository.save(domesticLocation);
-        Location savedInternationalLocation = locationRepository.save(internationalLocation);
-
-        Travel domesticTravel = travelRepository.save(Travel.builder()
-                .title("국내 여행")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedDomesticLocation)
-                .build());
-
-        Travel internationalTravel = travelRepository.save(Travel.builder()
-                .title("해외 여행")
-                .userNumber(1)
-                .viewCount(0)
-                .periodType(PeriodType.NONE)
-                .genderType(GenderType.NONE)
-                .createdAt(LocalDateTime.now())
-                .status(TravelStatus.IN_PROGRESS)
-                .location(savedInternationalLocation)
-                .build());
-
-        // when: "국내" 필터링
-        TravelSearchCondition domesticCondition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .locationTypes(List.of("국내"))
-                .build();
-
-        Page<TravelSearchDto> domesticResults = travelRepository.search(domesticCondition);
-
-        // then
-        assertThat(domesticResults.getTotalElements()).isEqualTo(1);
-        assertThat(domesticResults.getContent().get(0).getTitle()).isEqualTo("국내 여행");
-
-        // when: "해외" 필터링
-        TravelSearchCondition internationalCondition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .locationTypes(List.of("해외"))
-                .build();
-
-        Page<TravelSearchDto> internationalResults = travelRepository.search(internationalCondition);
-
-        // then
-        assertThat(internationalResults.getTotalElements()).isEqualTo(1);
-        assertThat(internationalResults.getContent().get(0).getTitle()).isEqualTo("해외 여행");
-
-        // when: "국내", "해외" 모두 필터링
-        TravelSearchCondition bothCondition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .locationTypes(List.of("국내", "해외"))
-                .build();
-
-        Page<TravelSearchDto> bothResults = travelRepository.search(bothCondition);
-
-        // then
-        assertThat(bothResults.getTotalElements()).isEqualTo(2);
-        assertThat(bothResults.getContent().stream().map(TravelSearchDto::getTitle))
-                .containsExactlyInAnyOrder("국내 여행", "해외 여행");
-    }*/
-
-
+//
 //    @DisplayName("findEnrollmentsByUserNumber: 사용자의 신청한 여행 목록 조회")
 //    @Test
 //    public void findEnrollmentsByUserNumber_ShouldReturnListOfEnrollments() {
@@ -875,4 +181,470 @@ class TravelCustomRepositoryImplTest {
 //        System.out.println("Enrollment Number: " + tuple.get(0, Long.class));
 //        System.out.println("Travel Number: " + tuple.get(1, Integer.class));
 //    }
+
+    @DisplayName("search: keyword가 포함된 여행을 가져올 수 있다.")
+    @Test
+    public void searchWithKeyword() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "Seoul 여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "키워드", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .keyword("키워드")
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent()).hasSize(1)
+                .extracting("title")
+                .allMatch(title -> ((String) title).contains("키워드"));
+    }
+
+    @DisplayName("search: 장소 이름에 keyword가 포함된 여행을 가져올 수 있다.")
+    @Test
+    public void searchWithKeywordThroughTitleAndLocation() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        Location location2 = locationRepository.save(createLocation("Busan", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행1", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location2, "여행2", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .keyword("Seoul")
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent()).hasSize(1)
+                .extracting("location")
+                .allMatch(locationName -> ((String) locationName).contains("Seoul"));
+    }
+
+
+    @DisplayName("search: 검색 키워드가 주어지지 않으면 필터링 조건으로 작용하지 않는다.")
+    @Test
+    public void searchWithoutKeyword() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "Seoul 여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "키워드", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getContent()).hasSize(2);
+    }
+
+    @DisplayName("search: 콘텐츠의 상태가 IN_PROGRESS, CLOSED인 여행만 가져온다.")
+    @Test
+    public void searchOnlyActivated() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, DELETED, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, CLOSED, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getContent()).hasSize(2)
+                .extracting("postStatus")
+                .allMatch(status -> List.of(IN_PROGRESS.toString(), CLOSED.toString()).contains(status));
+    }
+
+    @DisplayName("search: 여러 개의 문자열이 주어질 때, 해당 문자열의 태그를 전부 포함하는 여행을 가져온다.")
+    @Test
+    public void searchWithTags() {
+        // given
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        tagRepository.saveAll(Arrays.asList(tag1, tag2));
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .tags(List.of("쇼핑", "자연"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(1)
+                .allSatisfy(dto -> assertThat(dto.getTags())
+                        .containsExactlyInAnyOrder("자연", "쇼핑")
+                );
+    }
+
+    @DisplayName("search: 주어지는 GenderType에 해당하는 여행을 가져올 수 있다.")
+    @Test
+    public void searchWithGenderFilter() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.WOMAN_ONLY,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MAN_ONLY,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .genderTypes(List.of("모두", "여자만"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber")
+                .containsExactlyInAnyOrder(travel1.getNumber(), travel2.getNumber());
+    }
+
+    @DisplayName("search: 주어지는 PeriodType에 해당하는 여행을 가져올 수 있다.")
+    @Test
+    public void searchWithPeriodFilter() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .periodTypes(List.of("한 달 이상", "3~4주"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber")
+                .containsExactlyInAnyOrder(travel1.getNumber(), travel2.getNumber());
+    }
+
+
+    @DisplayName("search: 주어지는 personTypes에 해당하는 여행을 가져올 수 있다.")
+    @Test
+    public void searchWithPersonRangeFilter() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 2, GenderType.MIXED,
+                dueDate, PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 3, GenderType.MIXED,
+                dueDate, PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 4, GenderType.MIXED,
+                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+        Travel travel4 = createTravel(
+                1, location, "여행", 0, 5, GenderType.MIXED,
+                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .personTypes(List.of("3~4명"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber")
+                .containsExactlyInAnyOrder(travel2.getNumber(), travel3.getNumber());
+    }
+
+
+    @DisplayName("search: 장소 필터링을 통해 국내 카테고리의 여행을 검색할 수 있다.")
+    @Test
+    public void searchDomesticTravelWithLocationFilter() {
+        // given
+        Location domesticLocation = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        Location internationalLocation = locationRepository.save(createLocation("London", LocationType.INTERNATIONAL));
+
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .locationTypes(List.of("국내"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> domesticResults = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(domesticResults.getContent()).hasSize(2)
+                .extracting("travelNumber")
+                .containsExactlyInAnyOrder(travel1.getNumber(), travel2.getNumber());
+    }
+
+    @DisplayName("search: 장소 필터링을 통해 해외 카테고리의 여행을 검색할 수 있다.")
+    @Test
+    public void searchInternationalTravelWithLocationFilter() {
+        // given
+        Location domesticLocation = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        Location internationalLocation = locationRepository.save(createLocation("London", LocationType.INTERNATIONAL));
+
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .locationTypes(List.of("해외"))
+                .build();
+
+        // when
+        Page<TravelSearchDto> domesticResults = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(domesticResults.getContent()).hasSize(2)
+                .extracting("travelNumber")
+                .containsExactlyInAnyOrder(travel2.getNumber(), travel3.getNumber());
+    }
+
+    @DisplayName("search: 검색할 때 정렬 키워드가 주어지지 않으면, dueDate가 빠른 순서대로 정렬된다.")
+    @Test
+    public void searchWithoutSortingType() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(2), PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getContent()).hasSize(3)
+                .extracting("travelNumber")
+                .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
+    }
+
+    @DisplayName("search: 추천순 정렬은 북마크 개수, 조회수가 많은 순서대로 여행을 가져온다.")
+    @Test
+    public void searchWithRecommendSorting() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 3, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 2, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        LocalDateTime createdAt = LocalDateTime.of(2024, 11, 6, 12, 0);
+        Bookmark bookmark1 = createBookmark(travel2.getNumber(), createdAt);
+        Bookmark bookmark2 = createBookmark(travel3.getNumber(), createdAt);
+        Bookmark bookmark3 = createBookmark(travel3.getNumber(), createdAt);
+        bookmarkRepository.saveAll(List.of(bookmark1, bookmark2, bookmark3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .sortingType("추천순")
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getContent()).hasSize(3)
+                .extracting("travelNumber")
+                .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
+    }
+
+    @DisplayName("search: 추천순 정렬에서 북마크가 동일한 경우 조회수가 많은 순서대로 여행을 가져온다.")
+    @Test
+    void searchWithRecommendSorting2() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel2 = createTravel(
+                1, location, "여행", 3, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        Travel travel3 = createTravel(
+                1, location, "여행", 1, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
+
+        LocalDateTime createdAt = LocalDateTime.of(2024, 11, 6, 12, 0);
+        Bookmark bookmark1 = createBookmark(travel1.getNumber(), createdAt);
+        Bookmark bookmark2 = createBookmark(travel2.getNumber(), createdAt);
+        Bookmark bookmark3 = createBookmark(travel3.getNumber(), createdAt);
+        bookmarkRepository.saveAll(List.of(bookmark1, bookmark2, bookmark3));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .sortingType("추천순")
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+
+        // then
+        assertThat(results.getContent()).hasSize(3)
+                .extracting("travelNumber")
+                .containsExactly(travel2.getNumber(), travel3.getNumber(), travel1.getNumber());
+    }
+
+
+    private Users createHostUser() {
+        return Users.builder()
+                .userNumber(1)
+                .userPw("1234")
+                .userEmail("test@mail.com")
+                .userName("주최자 이름")
+                .userGender(Gender.M)
+                .userAgeGroup(AgeGroup.TEEN)
+                .userStatus(UserStatus.ABLE)
+                .build();
+    }
+
+    private Location createLocation(String locationName, LocationType locationType) {
+        return Location.builder()
+                .locationName(locationName)
+                .locationType(locationType)
+                .build();
+    }
+
+    private Travel createTravel(
+            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
+            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+    ) {
+        return Travel.builder()
+                .userNumber(hostNumber)
+                .location(location)
+                .locationName(location.getLocationName())
+                .title(title)
+                .details("여행 내용")
+                .viewCount(viewCount)
+                .maxPerson(maxPerson)
+                .genderType(genderType)
+                .dueDate(dueDate)
+                .periodType(periodType)
+                .status(status)
+                .tags(tags)
+                .build();
+    }
+
+    private Bookmark createBookmark(int travelNumber, LocalDateTime createdAt) {
+        return Bookmark.builder()
+                .userNumber(1)
+                .travelNumber(travelNumber)
+                .bookmarkDate(createdAt)
+                .build();
+    }
+
 }
+

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -117,10 +117,16 @@ class TravelCustomRepositoryImplTest {
                 .status(EnrollmentStatus.ACCEPTED)
                 .build());
     }
+
     @AfterEach
     void tearDown() {
         // 데이터 삭제
-        locationRepository.deleteAll();
+        travelTagRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        tagRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        enrollmentRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
     }
 
     @DisplayName("getDetailsByNumber: 여행콘텐츠 식별자로 디테일 정보를 가져온다")
@@ -128,7 +134,7 @@ class TravelCustomRepositoryImplTest {
     public void getDetailsByNumber() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -172,7 +178,7 @@ class TravelCustomRepositoryImplTest {
     public void findAllSortedByCreatedAt() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -211,7 +217,7 @@ class TravelCustomRepositoryImplTest {
         // given
         travelRepository.deleteAll();
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -233,7 +239,7 @@ class TravelCustomRepositoryImplTest {
         // given
         //travelRepository.deleteAll();
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -318,7 +324,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithKeyword() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -352,7 +358,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithKeywordThroughTitleAndLocation() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("영국"+System.currentTimeMillis())
+                .locationName("영국" + System.currentTimeMillis())
                 .locationType(LocationType.INTERNATIONAL)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -360,12 +366,12 @@ class TravelCustomRepositoryImplTest {
                 .title("추가 테스트 데이터")
                 .userNumber(1)
                 .viewCount(0)
-                .locationName("영국"+System.currentTimeMillis())
+                .locationName("영국" + System.currentTimeMillis())
                 .periodType(PeriodType.NONE)
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel2 = travelRepository.save(Travel.builder()
                 .title("영국 테스트 데이터")
@@ -396,7 +402,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithoutKeyword() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -430,7 +436,7 @@ class TravelCustomRepositoryImplTest {
     public void searchOnlyActivated() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -475,7 +481,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithPaging() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -512,7 +518,7 @@ class TravelCustomRepositoryImplTest {
         // given
         Tag tag = tagRepository.save(Tag.of("테스트"));
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -554,7 +560,7 @@ class TravelCustomRepositoryImplTest {
         Tag tag2 = tagRepository.save(Tag.of("투어"));
         Tag tag3 = tagRepository.save(Tag.of("도시"));
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -581,7 +587,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         //tags: 한국, 투어
         travelTagRepository.save(TravelTag.of(travel2, tag1));
@@ -610,7 +616,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithGenderFilter() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -622,7 +628,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.WOMAN_ONLY)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel2 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터2")
@@ -632,7 +638,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.MIXED)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel3 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터3")
@@ -642,7 +648,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.MAN_ONLY)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(0, 5))
@@ -663,7 +669,7 @@ class TravelCustomRepositoryImplTest {
     public void searchWithPeriodFilter() {
         // given
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -675,7 +681,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel2 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터2")
@@ -685,7 +691,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel3 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터3")
@@ -695,7 +701,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(0, 5))
@@ -720,7 +726,7 @@ class TravelCustomRepositoryImplTest {
         // given
         travelRepository.deleteAll();
         Location travelLocation = Location.builder()
-                .locationName("Seoul"+System.currentTimeMillis())
+                .locationName("Seoul" + System.currentTimeMillis())
                 .locationType(LocationType.DOMESTIC)
                 .build();
         Location savedLocation = locationRepository.save(travelLocation);
@@ -733,7 +739,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel2 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터2")
@@ -744,7 +750,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         Travel travel3 = travelRepository.save(Travel.builder()
                 .title("추가 테스트 데이터3")
@@ -755,7 +761,7 @@ class TravelCustomRepositoryImplTest {
                 .genderType(GenderType.NONE)
                 .createdAt(LocalDateTime.now())
                 .status(TravelStatus.IN_PROGRESS)
-                        .location(savedLocation)
+                .location(savedLocation)
                 .build());
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(0, 5))
@@ -848,8 +854,6 @@ class TravelCustomRepositoryImplTest {
         assertThat(bothResults.getContent().stream().map(TravelSearchDto::getTitle))
                 .containsExactlyInAnyOrder("국내 여행", "해외 여행");
     }*/
-
-
 
 
 //    @DisplayName("findEnrollmentsByUserNumber: 사용자의 신청한 여행 목록 조회")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelRepositoryTest.java
@@ -1,0 +1,100 @@
+package swyp.swyp6_team7.travel.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import swyp.swyp6_team7.config.DataConfig;
+import swyp.swyp6_team7.location.domain.Location;
+import swyp.swyp6_team7.location.domain.LocationType;
+import swyp.swyp6_team7.location.repository.LocationRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(DataConfig.class)
+@DataJpaTest
+class TravelRepositoryTest {
+
+    @Autowired
+    private TravelRepository travelRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+
+    @DisplayName("TravelNumber가 주어질 때, 해당 Travel의 viewCount를 1 증가시킨다.")
+    @Test
+    void updateViewCountPlusOneByTravelNumber() {
+        // given
+        int nowViewCount = 5;
+        Travel travel = travelRepository.save(createTravel(nowViewCount, LocalDateTime.now()));
+
+        // when
+        travelRepository.updateViewCountPlusOneByTravelNumber(travel.getNumber());
+
+        // then
+        assertThat(travelRepository.findAll()).hasSize(1)
+                .extracting("viewCount")
+                .contains(6);
+    }
+
+    @DisplayName("TravelNumber가 주어질 때, 해당 Travel의 enrollmentLastViewedAt를 가져올 수 있다.")
+    @Test
+    void getEnrollmentsLastViewedAtByNumber() {
+        // given
+        LocalDateTime viewedAt = LocalDateTime.of(2024, 11, 8, 12, 0);
+        Travel travel = travelRepository.save(createTravel(0, viewedAt));
+
+        // when
+        LocalDateTime result = travelRepository.getEnrollmentsLastViewedAtByNumber(travel.getNumber());
+
+        // then
+        assertThat(result)
+                .isEqualTo(LocalDateTime.of(2024, 11, 8, 12, 0));
+    }
+
+    @DisplayName("TravelNumber와 LocalDateTime이 주어질 때, 해당 Travel의 enrollmentLastViewedAt의 값을 수정한다.")
+    @Test
+    void updateEnrollmentsLastViewedAtByNumber() {
+        // given
+        LocalDateTime viewedAt = LocalDateTime.of(2024, 11, 8, 12, 0);
+        Travel travel = travelRepository.save(createTravel(0, viewedAt));
+
+        LocalDateTime updateViewedAt = LocalDateTime.of(2024, 11, 8, 15, 0);
+
+        // when
+        travelRepository.updateEnrollmentsLastViewedAtByNumber(travel.getNumber(), updateViewedAt);
+
+        // then
+        assertThat(travelRepository.findAll()).hasSize(1)
+                .extracting("enrollmentsLastViewedAt")
+                .contains(LocalDateTime.of(2024, 11, 8, 15, 0));
+    }
+
+
+    private Travel createTravel(int nowViewCount, LocalDateTime enrollmentLastViewdAt) {
+        Location location = locationRepository.save(Location.builder()
+                .locationName("여행지명")
+                .locationType(LocationType.DOMESTIC)
+                .build());
+
+        return Travel.builder()
+                .userNumber(1)
+                .location(location)
+                .viewCount(nowViewCount)
+                .genderType(GenderType.MIXED)
+                .periodType(PeriodType.ONE_WEEK)
+                .status(TravelStatus.IN_PROGRESS)
+                .enrollmentsLastViewedAt(enrollmentLastViewdAt)
+                .build();
+    }
+
+}
+

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
@@ -1,0 +1,200 @@
+package swyp.swyp6_team7.travel.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import swyp.swyp6_team7.location.domain.Location;
+import swyp.swyp6_team7.location.domain.LocationType;
+import swyp.swyp6_team7.location.repository.LocationRepository;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.repository.TagRepository;
+import swyp.swyp6_team7.tag.repository.TravelTagRepository;
+import swyp.swyp6_team7.tag.repository.UserTagPreferenceRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static swyp.swyp6_team7.travel.domain.TravelStatus.IN_PROGRESS;
+
+
+@SpringBootTest
+class TravelHomeServiceTest {
+
+    @Autowired
+    private TravelHomeService travelHomeService;
+
+    @Autowired
+    private TravelRepository travelRepository;
+
+    @Autowired
+    private TravelTagRepository travelTagRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @MockBean
+    private UserTagPreferenceRepository userTagPreferenceRepository;
+
+    @AfterEach
+    void tearDown() {
+        travelTagRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        tagRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
+    }
+
+
+    @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 큰 순서대로 여행 목록을 가져온다.")
+    @Test
+    void getRecommendTravelsByUser() {
+        // given
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        Tag tag3 = Tag.of("먹방");
+        Tag tag4 = Tag.of("즉흥");
+        tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        Travel travel3 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
+        Travel travel4 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
+        travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
+
+        given(userTagPreferenceRepository.findPreferenceTagsByUserNumber(any(Integer.class)))
+                .willReturn(Arrays.asList("쇼핑", "자연", "먹방"));
+
+        // when
+        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(4)
+                .extracting("travelNumber", "tags", "preferredNumber", "registerDue")
+                .containsExactly(
+                        tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3, dueDate),
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate),
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑"), 1, dueDate),
+                        tuple(travel3.getNumber(), Arrays.asList("쇼핑", "즉흥"), 1, dueDate.plusDays(1))
+                );
+    }
+
+    @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 동일한 경우 registerDue가 빠른 순서대로 여행을 가져온다.")
+    @Test
+    void getRecommendTravelsByUserWhenSamePreferredNumber() {
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        tagRepository.saveAll(List.of(tag1, tag2));
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        Travel travel2 = createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        given(userTagPreferenceRepository.findPreferenceTagsByUserNumber(any(Integer.class)))
+                .willReturn(Arrays.asList("쇼핑", "자연"));
+
+        // when
+        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber", "tags", "preferredNumber", "registerDue")
+                .containsExactly(
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate),
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate.plusDays(1))
+                );
+    }
+
+    @DisplayName("preferredNumber, registerDue가 동일한 경우 title을 기준으로 가나다 순서대로 가져온다.")
+    @Test
+    void getRecommendTravelsByUserWhenSamePreferredNumberSameRegisterDue() {
+        Tag tag1 = Tag.of("쇼핑");
+        Tag tag2 = Tag.of("자연");
+        tagRepository.saveAll(List.of(tag1, tag2));
+
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = createTravel(
+                1, location, "여행-나", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        Travel travel2 = createTravel(
+                1, location, "여행-가", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+        travelRepository.saveAll(List.of(travel1, travel2));
+
+        given(userTagPreferenceRepository.findPreferenceTagsByUserNumber(any(Integer.class)))
+                .willReturn(Arrays.asList("쇼핑", "자연"));
+
+        // when
+        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber", "tags", "preferredNumber", "registerDue", "title")
+                .containsExactly(
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate, "여행-가"),
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate, "여행-나")
+                );
+    }
+
+    private Location createLocation(String locationName, LocationType locationType) {
+        return Location.builder()
+                .locationName(locationName)
+                .locationType(locationType)
+                .build();
+    }
+
+    private Travel createTravel(
+            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
+            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+    ) {
+        return Travel.builder()
+                .userNumber(hostNumber)
+                .location(location)
+                .locationName(location.getLocationName())
+                .title(title)
+                .details("여행 내용")
+                .viewCount(viewCount)
+                .maxPerson(maxPerson)
+                .genderType(genderType)
+                .dueDate(dueDate)
+                .periodType(periodType)
+                .status(status)
+                .tags(tags)
+                .build();
+    }
+
+}

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -81,7 +81,7 @@ class TravelServiceTest {
                 .genderType(GenderType.MIXED.toString())
                 .dueDate(dueDate)
                 .periodType(PeriodType.ONE_WEEK.toString())
-                .tags(List.of())
+                .tags(List.of("쇼핑"))
                 .completionStatus(true)
                 .build();
 
@@ -101,7 +101,8 @@ class TravelServiceTest {
         assertThat(createdTravel.getPeriodType()).isEqualTo(PeriodType.ONE_WEEK);
         assertThat(createdTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
         assertThat(createdTravel.getEnrollmentsLastViewedAt()).isNull();
-        assertThat(createdTravel.getTravelTags()).isEmpty();
+        assertThat(createdTravel.getTravelTags()).hasSize(1);
+        assertThat(createdTravel.getTravelTags().get(0).getTag().getName()).isEqualTo("쇼핑");
         assertThat(createdTravel.getCompanions()).isEmpty();
         assertThat(createdTravel.getDeletedUser()).isNull();
     }
@@ -112,13 +113,14 @@ class TravelServiceTest {
         // given
         String defaultProfileUrl = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
         Users host = userRepository.save(createHostUser());
+        Integer requestUserNumber = host.getUserNumber() + 1;
 
         Location location = locationRepository.save(createLocation("Seoul"));
         LocalDate dueDate = LocalDate.of(2024, 11, 4);
         Travel savedTravel = travelRepository.save(createTravel(host.getUserNumber(), location, dueDate, TravelStatus.IN_PROGRESS));
 
         // when
-        TravelDetailResponse travelDetails = travelService.getDetailsByNumber(savedTravel.getNumber(), 2);
+        TravelDetailResponse travelDetails = travelService.getDetailsByNumber(savedTravel.getNumber(), requestUserNumber);
 
         // then
         assertThat(travelDetails.getTravelNumber()).isEqualTo(savedTravel.getNumber());
@@ -149,6 +151,7 @@ class TravelServiceTest {
     void getDetailsByNumberWhenDeletedStatus() {
         // given
         Users host = userRepository.save(createHostUser());
+        Integer requestUserNumber = host.getUserNumber() + 1;
 
         Location location = locationRepository.save(createLocation("Seoul"));
         LocalDate dueDate = LocalDate.of(2024, 11, 4);
@@ -156,7 +159,7 @@ class TravelServiceTest {
 
         // when // then
         assertThatThrownBy(() -> {
-            travelService.getDetailsByNumber(savedTravel.getNumber(), 2);
+            travelService.getDetailsByNumber(savedTravel.getNumber(), requestUserNumber);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Deleted 상태의 여행 콘텐츠입니다.");
     }
@@ -166,6 +169,7 @@ class TravelServiceTest {
     void getDetailsByNumberWhenDraftStatus() {
         // given
         Users host = userRepository.save(createHostUser());
+        Integer requestUserNumber = host.getUserNumber() + 1;
 
         Location location = locationRepository.save(createLocation("Seoul"));
         LocalDate dueDate = LocalDate.of(2024, 11, 4);
@@ -173,7 +177,7 @@ class TravelServiceTest {
 
         // when // then
         assertThatThrownBy(() -> {
-            travelService.getDetailsByNumber(savedTravel.getNumber(), 2);
+            travelService.getDetailsByNumber(savedTravel.getNumber(), requestUserNumber);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("DRAFT 상태의 여행 조회는 작성자만 가능합니다.");
     }

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -15,6 +15,7 @@ import swyp.swyp6_team7.member.entity.Gender;
 import swyp.swyp6_team7.member.entity.UserStatus;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.repository.TagRepository;
 import swyp.swyp6_team7.tag.repository.TravelTagRepository;
 import swyp.swyp6_team7.travel.domain.GenderType;
@@ -139,7 +140,7 @@ class TravelServiceTest {
         assertThat(travelDetails.getGenderType()).isEqualTo(GenderType.MIXED.toString());
         assertThat(travelDetails.getDueDate()).isEqualTo(dueDate);
         assertThat(travelDetails.getPeriodType()).isEqualTo(PeriodType.ONE_WEEK.toString());
-        assertThat(travelDetails.getTags()).isEmpty();
+        assertThat(travelDetails.getTags()).hasSize(1);
         assertThat(travelDetails.getPostStatus()).isEqualTo(TravelStatus.IN_PROGRESS.toString());
         assertThat(travelDetails.isHostUserCheck()).isFalse();
         assertThat(travelDetails.getEnrollmentNumber()).isNull();
@@ -200,7 +201,7 @@ class TravelServiceTest {
                 .genderType(GenderType.WOMAN_ONLY.toString())
                 .dueDate(LocalDate.of(2024, 11, 5))
                 .periodType(PeriodType.MORE_THAN_MONTH.toString())
-                .tags(List.of())
+                .tags(List.of("쇼핑"))
                 .completionStatus(true)
                 .build();
 
@@ -218,7 +219,13 @@ class TravelServiceTest {
         assertThat(updatedTravel.getDueDate()).isEqualTo(LocalDate.of(2024, 11, 5));
         assertThat(updatedTravel.getPeriodType()).isEqualTo(PeriodType.MORE_THAN_MONTH);
         assertThat(updatedTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
-        assertThat(updatedTravel.getTravelTags()).isEmpty();
+        assertThat(updatedTravel.getTravelTags()).hasSize(1);
+        assertThat(updatedTravel.getTravelTags().get(0).getTag().getName()).isEqualTo("쇼핑");
+
+        assertThat(travelTagRepository.findAll()).hasSize(1);
+        assertThat(tagRepository.findAll()).hasSize(2)
+                .extracting("name")
+                .contains("자연", "쇼핑");
     }
 
     @DisplayName("update: 여행 콘텐츠를 수정할 때, 작성자가 아니라면 예외가 발생한다.")
@@ -304,6 +311,8 @@ class TravelServiceTest {
     }
 
     private Travel createTravel(int hostUserNumber, Location location, LocalDate dueDate, TravelStatus status) {
+        Tag tag1 = tagRepository.save(Tag.of("자연"));
+
         return Travel.builder()
                 .userNumber(hostUserNumber)
                 .location(location)
@@ -316,6 +325,7 @@ class TravelServiceTest {
                 .dueDate(dueDate)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(status)
+                .tags(List.of(tag1))
                 .build();
     }
 

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -1,12 +1,12 @@
 package swyp.swyp6_team7.travel.service;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
@@ -14,78 +14,103 @@ import swyp.swyp6_team7.member.entity.AgeGroup;
 import swyp.swyp6_team7.member.entity.Gender;
 import swyp.swyp6_team7.member.entity.UserStatus;
 import swyp.swyp6_team7.member.entity.Users;
-import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.tag.service.TravelTagService;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
-@TestPropertySource(properties = {
-        "kakao.client-id=fake-client-id",
-        "kakao.client-secret=fake-client-secret",
-        "kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao",
-        "kakao.token-url=https://kauth.kakao.com/oauth/token",
-        "kakao.user-info-url=https://kapi.kakao.com/v2/user/me"
-})
 class TravelServiceTest {
 
     @Autowired
     private TravelService travelService;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private LocationRepository locationRepository;
+
     @Autowired
     private TravelRepository travelRepository;
-    
-    Users user;
 
-    @BeforeEach
-    void setUp() {
-        travelRepository.deleteAll();
-        locationRepository.deleteAll();
-        userRepository.deleteAll();
-        user = userRepository.save(Users.builder()
-                .userEmail("test@naver.com")
-                .userPw("1234")
-                .userName("username")
-                .userGender(Gender.M)
-                .userAgeGroup(AgeGroup.TWENTY)
-                .userRegDate(LocalDateTime.now())
-                .userStatus(UserStatus.ABLE)
+    @Mock
+    private TravelTagService travelTagService;
 
-                .build());
+    @Mock
+    private LocationRepository locationRepository;
 
+    @AfterEach
+    void tearDown() {
+        travelRepository.deleteAllInBatch();
     }
 
-    @DisplayName("create: 이메일로 유저를 가져와 여행 콘텐츠를 만들 수 있다")
+    @DisplayName("create: 여행 콘텐츠를 만들 수 있다")
     @Test
     @DirtiesContext
     public void createTravelWithUser() {
         // given
-        Location travelLocation = Location.builder()
-                .locationName("Seoul")
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
+        travelRepository.deleteAllInBatch();
+
+        Users user = createUser();
+        Location travelLocation = new Location(1L, "서울", LocationType.DOMESTIC);
+
+        LocalDate dueDate = LocalDate.of(2024, 11, 4);
         TravelCreateRequest request = TravelCreateRequest.builder()
-                .title("test travel post")
+                .locationName("Seoul")
+                .title("여행 제목")
+                .details("여행 내용")
+                .maxPerson(2)
+                .genderType(GenderType.MIXED.toString())
+                .dueDate(dueDate)
+                .periodType(PeriodType.ONE_WEEK.toString())
+                .tags(List.of())
                 .completionStatus(true)
-                .locationName(savedLocation.getLocationName())
                 .build();
+
+        given(locationRepository.findByLocationName(anyString()))
+                .willReturn(Optional.of(travelLocation));
+        given(travelTagService.create(any(Travel.class), anyList()))
+                .willReturn(List.of());
 
         // when
-        Travel createdTravel = travelService.create(request, "test@naver.com");
+        Travel createdTravel = travelService.create(request, user.getUserNumber());
 
         // then
-        assertThat(createdTravel.getTitle()).isEqualTo(request.getTitle());
-        assertThat(createdTravel.getUserNumber()).isEqualTo(user.getUserNumber());
-        assertThat(createdTravel.getLocation().getLocationName()).isEqualTo(savedLocation.getLocationName());
+        assertThat(travelRepository.findAll()).hasSize(1);
+        assertThat(createdTravel.getUserNumber()).isEqualTo(1);
+        assertThat(createdTravel.getLocationName()).isEqualTo("Seoul");
+        assertThat(createdTravel.getTitle()).isEqualTo("여행 제목");
+        assertThat(createdTravel.getDetails()).isEqualTo("여행 내용");
+        assertThat(createdTravel.getViewCount()).isEqualTo(0);
+        assertThat(createdTravel.getMaxPerson()).isEqualTo(2);
+        assertThat(createdTravel.getGenderType()).isEqualTo(GenderType.MIXED);
+        assertThat(createdTravel.getDueDate()).isEqualTo(dueDate);
+        assertThat(createdTravel.getPeriodType()).isEqualTo(PeriodType.ONE_WEEK);
+        assertThat(createdTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
+        assertThat(createdTravel.getEnrollmentsLastViewedAt()).isNull();
+        assertThat(createdTravel.getTravelTags()).isEmpty();
+        assertThat(createdTravel.getCompanions()).isEmpty();
+        assertThat(createdTravel.getDeletedUser()).isNull();
+    }
 
+    private Users createUser() {
+        return Users.builder()
+                .userNumber(1)
+                .userEmail("test@naver.com")
+                .userPw("1234")
+                .userName("사용자명")
+                .userGender(Gender.M)
+                .userAgeGroup(AgeGroup.TWENTY)
+                .userRegDate(LocalDateTime.now())
+                .userStatus(UserStatus.ABLE)
+                .build();
     }
 
 }

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -6,29 +6,25 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
-import swyp.swyp6_team7.member.entity.AgeGroup;
-import swyp.swyp6_team7.member.entity.Gender;
-import swyp.swyp6_team7.member.entity.UserStatus;
-import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.tag.service.TravelTagService;
 import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
+import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
@@ -40,28 +36,26 @@ class TravelServiceTest {
     @Autowired
     private TravelRepository travelRepository;
 
+    @Autowired
+    private LocationRepository locationRepository;
+
     @Mock
     private TravelTagService travelTagService;
 
-    @Mock
-    private LocationRepository locationRepository;
 
     @AfterEach
     void tearDown() {
         travelRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
     }
 
     @DisplayName("create: 여행 콘텐츠를 만들 수 있다")
     @Test
-    @DirtiesContext
-    public void createTravelWithUser() {
+    public void create() {
         // given
-        travelRepository.deleteAllInBatch();
-
-        Users user = createUser();
-        Location travelLocation = new Location(1L, "서울", LocationType.DOMESTIC);
-
+        Location location = locationRepository.save(createLocation("Seoul"));
         LocalDate dueDate = LocalDate.of(2024, 11, 4);
+
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("Seoul")
                 .title("여행 제목")
@@ -74,13 +68,11 @@ class TravelServiceTest {
                 .completionStatus(true)
                 .build();
 
-        given(locationRepository.findByLocationName(anyString()))
-                .willReturn(Optional.of(travelLocation));
         given(travelTagService.create(any(Travel.class), anyList()))
                 .willReturn(List.of());
 
         // when
-        Travel createdTravel = travelService.create(request, user.getUserNumber());
+        Travel createdTravel = travelService.create(request, 1);
 
         // then
         assertThat(travelRepository.findAll()).hasSize(1);
@@ -100,16 +92,131 @@ class TravelServiceTest {
         assertThat(createdTravel.getDeletedUser()).isNull();
     }
 
-    private Users createUser() {
-        return Users.builder()
-                .userNumber(1)
-                .userEmail("test@naver.com")
-                .userPw("1234")
-                .userName("사용자명")
-                .userGender(Gender.M)
-                .userAgeGroup(AgeGroup.TWENTY)
-                .userRegDate(LocalDateTime.now())
-                .userStatus(UserStatus.ABLE)
+    @DisplayName("update: 여행 콘텐츠를 수정할 수 있다.")
+    @Transactional
+    @Test
+    void update() {
+        // given
+        int hostUserNumber = 1;
+        Location location = locationRepository.save(createLocation("Seoul"));
+        LocalDate dueDate = LocalDate.of(2024, 11, 4);
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+
+        TravelUpdateRequest request = TravelUpdateRequest.builder()
+                .locationName("Seoul")
+                .title("여행 제목 수정")
+                .details("여행 내용 수정")
+                .maxPerson(3)
+                .genderType(GenderType.WOMAN_ONLY.toString())
+                .dueDate(LocalDate.of(2024, 11, 5))
+                .periodType(PeriodType.MORE_THAN_MONTH.toString())
+                .tags(List.of())
+                .completionStatus(true)
+                .build();
+
+        given(travelTagService.update(any(Travel.class), anyList()))
+                .willReturn(List.of());
+
+        // when
+        Travel updatedTravel = travelService.update(savedTravel.getNumber(), request, 1);
+
+        // then
+        assertThat(travelRepository.findAll()).hasSize(1);
+        assertThat(updatedTravel.getUserNumber()).isEqualTo(1);
+        assertThat(updatedTravel.getLocationName()).isEqualTo("Seoul");
+        assertThat(updatedTravel.getTitle()).isEqualTo("여행 제목 수정");
+        assertThat(updatedTravel.getDetails()).isEqualTo("여행 내용 수정");
+        assertThat(updatedTravel.getMaxPerson()).isEqualTo(3);
+        assertThat(updatedTravel.getGenderType()).isEqualTo(GenderType.WOMAN_ONLY);
+        assertThat(updatedTravel.getDueDate()).isEqualTo(LocalDate.of(2024, 11, 5));
+        assertThat(updatedTravel.getPeriodType()).isEqualTo(PeriodType.MORE_THAN_MONTH);
+        assertThat(updatedTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
+        assertThat(updatedTravel.getTravelTags()).isEmpty();
+    }
+
+    @DisplayName("update: 여행 콘텐츠를 수정할 때, 작성자가 아니라면 예외가 발생한다.")
+    @Test
+    void updateWhenNotHost() {
+        // given
+        int hostUserNumber = 1;
+        int requestUserNumber = 2;
+
+        Location location = locationRepository.save(createLocation("Seoul"));
+        LocalDate dueDate = LocalDate.of(2024, 11, 4);
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+
+        TravelUpdateRequest request = TravelUpdateRequest.builder()
+                .tags(List.of())
+                .completionStatus(true)
+                .build();
+
+        // when //then
+        assertThatThrownBy(() -> {
+            travelService.update(savedTravel.getNumber(), request, requestUserNumber);
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("여행 수정 권한이 없습니다.");
+    }
+
+    @DisplayName("delete: 여행 콘텐츠를 삭제할 수 있다.")
+    @Test
+    void delete() {
+        // given
+        int hostUserNumber = 1;
+        Location location = locationRepository.save(createLocation("Seoul"));
+        LocalDate dueDate = LocalDate.of(2024, 11, 4);
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+
+        // when
+        travelService.delete(savedTravel.getNumber(), hostUserNumber);
+
+        // then
+        List<Travel> travels = travelRepository.findAll();
+        assertThat(travels).hasSize(1)
+                .extracting("number", "status")
+                .contains(
+                        tuple(savedTravel.getNumber(), TravelStatus.DELETED)
+                );
+    }
+
+    @DisplayName("delete: 여행 콘텐츠를 삭제할 때, 작성자가 아니라면 예외가 발생한다.")
+    @Test
+    void deleteWhenNotHost() {
+        // given
+        int hostUserNumber = 1;
+        int requestUserNumber = 2;
+
+        Location location = locationRepository.save(createLocation("Seoul"));
+        LocalDate dueDate = LocalDate.of(2024, 11, 4);
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+
+        // when //then
+        assertThatThrownBy(() -> {
+            travelService.delete(savedTravel.getNumber(), requestUserNumber);
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("여행 삭제 권한이 없습니다.");
+    }
+
+
+    private Location createLocation(String locationName) {
+        return Location.builder()
+                .locationName(locationName)
+                .locationType(LocationType.DOMESTIC)
+                .build();
+    }
+
+    private Travel createTravel(int hostUserNumber, Location location, LocalDate dueDate, TravelStatus status) {
+        return Travel.builder()
+                .userNumber(hostUserNumber)
+                .location(location)
+                .locationName(location.getLocationName())
+                .title("여행 제목")
+                .details("여행 내용")
+                .viewCount(0)
+                .maxPerson(2)
+                .genderType(GenderType.MIXED)
+                .dueDate(dueDate)
+                .periodType(PeriodType.ONE_WEEK)
+                .status(status)
                 .build();
     }
 


### PR DESCRIPTION
## 🔗 Issue Number

refactor: 여행 관련 기능 리팩토링 #136

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
Travel CRUD, Home, Search와 관련된 기능을 리팩토링하고 테스트코드, 로그를 추가함
- 로그인 사용자의 번호를 Controller단에서 가져와 메서드를 통해 넘겨주는 방식으로 통일함
  - Service 테스트가 용이해짐
- 각 기능에 대해 Service, Repository 테스트 코드 수정 및 추가
  - 기존에 작성되어 있던 테스트코드를 검토 및 수정 완료
  - `TravelCustomRepositoryImpl` 테스트코드 재작성
- Travel 생성 로직 수정
  - DTO에서 엔티티를 생성하는 방식을 static 메서드를 통해 Travel에서 객체를 생성하도록 수정함
  - 여행 생성 시 TravelTag를 따로 생성해서 저장하는 방식을 JPA 연관 관계를 고려한 방식으로 수정함

## 🔖 리뷰 요구사항(선택)

.


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
