### PR TITLE
feat: 여행 인원 마감 알림 수신 대상 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
@@ -10,17 +10,22 @@ import java.util.List;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
     List<Bookmark> findByUserNumber(Integer userNumber);
 
+    @Query("SELECT b.userNumber FROM Bookmark b WHERE b.travelNumber = :travelNumber")
+    List<Integer> findUserNumberByTravelNumber(@Param("travelNumber") Integer travelNumber);
+
     int countByUserNumber(Integer userNumber);
+
     int countByTravelNumber(int travelNumber);
 
     // 가장 오래된 북마크 조회
     @Query("SELECT b FROM Bookmark b WHERE b.userNumber = :userNumber ORDER BY b.bookmarkDate ASC")
     List<Bookmark> findOldestByUserNumber(@Param("userNumber") Integer userNumber);
+
     @Query("SELECT b FROM Bookmark b WHERE b.userNumber = :userNumber")
     List<Bookmark> findBookmarksByUserNumber(@Param("userNumber") Integer userNumber);
 
-
     boolean existsByUserNumberAndTravelNumber(Integer userNumber, Integer travelNumber);
+
     int deleteByUserNumberAndTravelNumber(Integer userNumber, Integer travelNumber);
 
 }

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
@@ -10,8 +10,6 @@ public interface EnrollmentCustomRepository {
 
     List<EnrollmentResponse> findEnrollmentsByTravelNumber(int travelNumber);
 
-    List<Integer> findEnrolledUserNumbersByTravelNumber(int travelNumber);
-
     List<Integer> findUserNumbersByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status);
 
     List<Tuple> findEnrollmentsByUserNumber(int userNumber);

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepository.java
@@ -1,6 +1,7 @@
 package swyp.swyp6_team7.enrollment.repository;
 
 import com.querydsl.core.Tuple;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 import swyp.swyp6_team7.enrollment.dto.EnrollmentResponse;
 
 import java.util.List;
@@ -10,6 +11,8 @@ public interface EnrollmentCustomRepository {
     List<EnrollmentResponse> findEnrollmentsByTravelNumber(int travelNumber);
 
     List<Integer> findEnrolledUserNumbersByTravelNumber(int travelNumber);
+
+    List<Integer> findUserNumbersByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status);
 
     List<Tuple> findEnrollmentsByUserNumber(int userNumber);
 

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
@@ -64,6 +64,17 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
     }
 
     @Override
+    public List<Integer> findUserNumbersByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status) {
+        return queryFactory
+                .select(enrollment.userNumber)
+                .from(enrollment)
+                .where(
+                        enrollment.travelNumber.eq(travelNumber),
+                        enrollment.status.eq(status)
+                ).distinct().fetch();
+    }
+
+    @Override
     public List<Tuple> findEnrollmentsByUserNumber(int userNumber) {
         return queryFactory
                 .select(enrollment.number, travel.number, enrollment.status)

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImpl.java
@@ -53,17 +53,6 @@ public class EnrollmentCustomRepositoryImpl implements EnrollmentCustomRepositor
     }
 
     @Override
-    public List<Integer> findEnrolledUserNumbersByTravelNumber(int travelNumber) {
-        return queryFactory
-                .select(enrollment.userNumber)
-                .from(enrollment)
-                .where(
-                        enrollment.travelNumber.eq(travelNumber),
-                        enrollment.status.eq(EnrollmentStatus.ACCEPTED)
-                ).fetch();
-    }
-
-    @Override
     public List<Integer> findUserNumbersByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status) {
         return queryFactory
                 .select(enrollment.userNumber)

--- a/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
+++ b/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
@@ -16,12 +16,15 @@ public class TravelNotificationDto extends NotificationDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate travelDueDate;
 
+    private Boolean travelHostUser;
+
 
     public TravelNotificationDto(TravelNotification notification) {
         super(notification);
         this.travelNumber = notification.getTravelNumber();
         this.travelTitle = notification.getTravelTitle();
         this.travelDueDate = notification.getTravelDueDate();
+        this.travelHostUser = notification.getTravelHost();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/NotificationMessageType.java
@@ -42,9 +42,21 @@ public enum NotificationMessageType {
         }
     },
 
-    TRAVEL_CLOSED("모집 마감 알림") {
+    TRAVEL_CLOSED_COMPANION("모집 마감 알림") {
         public String getContent(String travelTitle) {
             return String.format("참가하신 [%s]의 모집이 마감되었어요.", travelTitle);
+        }
+    },
+
+    TRAVEL_CLOSED_PENDING("모집 마감 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("참가 신청하신 [%s]의 모집이 마감되었어요.", travelTitle);
+        }
+    },
+
+    TRAVEL_CLOSED_BOOKMARKED("모집 마감 알림") {
+        public String getContent(String travelTitle) {
+            return String.format("즐겨찾기하신 [%s]의 모집이 마감되었어요.", travelTitle);
         }
     },
 

--- a/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import swyp.swyp6_team7.travel.domain.Travel;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,16 +28,20 @@ public class TravelNotification extends Notification {
     @Column(name = "travel_due_date")
     private LocalDate travelDueDate;
 
+    @Column(name = "travel_host")
+    private Boolean travelHost;
+
 
     public TravelNotification(
             Long number, LocalDateTime createdAt, Integer receiverNumber,
             String title, String content, Boolean isRead,
-            Integer travelNumber, String travelTitle, LocalDate travelDueDate
+            Integer travelNumber, String travelTitle, LocalDate travelDueDate, Boolean travelHost
     ) {
         super(number, createdAt, receiverNumber, title, content, isRead);
         this.travelNumber = travelNumber;
         this.travelTitle = travelTitle;
         this.travelDueDate = travelDueDate;
+        this.travelHost = travelHost;
     }
 
 
@@ -52,6 +57,7 @@ public class TravelNotification extends Notification {
                 "travelNumber=" + travelNumber +
                 ", travelTitle='" + travelTitle + '\'' +
                 ", travelDueDate=" + travelDueDate +
+                ", travelHost=" + travelHost +
                 '}';
     }
 

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -40,12 +40,12 @@ public class NotificationService {
 
     @Async
     public void createEnrollNotification(Travel targetTravel, int enrollUserNumber) {
-        // notification to host
+        // to 주최자
         Notification newNotificationToHost = NotificationMaker.travelEnrollmentMessageToHost(targetTravel);
         Notification createdNotificationToHost = notificationRepository.save(newNotificationToHost);
         log.info("여행 참가 신청 HOST 알림 - receiverNumber: {}, notificationNumber: {}", targetTravel.getUserNumber(), createdNotificationToHost.getNumber());
 
-        // notification to 신청자
+        // to 신청자
         Notification newNotification = NotificationMaker.travelEnrollmentMessage(targetTravel, enrollUserNumber);
         Notification createdNotification = notificationRepository.save(newNotification);
         log.info("여행 참가 신청 요청자 알림 - receiverNumber: {}, notificationNumber: {}", enrollUserNumber, createdNotification.getNumber());
@@ -116,13 +116,13 @@ public class NotificationService {
                     return new IllegalArgumentException("존재하지 않는 여행 콘텐츠입니다.");
                 });
 
-        // notification to host (댓글 작성자가 주최자가 아닌 경우에만 주최자용 알림 생성)
+        // to 주최자 (댓글 작성자가 주최자가 아닌 경우에만 주최자용 알림 생성)
         if (requestUserNumber != targetTravel.getUserNumber()) {
             notificationRepository.save(NotificationMaker.travelNewCommentMessageToHost(targetTravel));
         }
 
-        // notification to each enrollment (작성자는 알림 생성 제외)
-        List<Integer> enrolledUserNumbers = enrollmentRepository.findEnrolledUserNumbersByTravelNumber(targetTravel.getNumber());
+        // to 신청자 (작성자는 알림 생성 제외)
+        List<Integer> enrolledUserNumbers = enrollmentRepository.findUserNumbersByTravelNumberAndStatus(targetTravel.getNumber(), EnrollmentStatus.ACCEPTED);
         List<TravelCommentNotification> createdNotifications = enrolledUserNumbers.stream()
                 .distinct()
                 .filter(userNumber -> userNumber != requestUserNumber)

--- a/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
+++ b/src/main/java/swyp/swyp6_team7/notification/service/NotificationService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
 import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
 import swyp.swyp6_team7.notification.dto.NotificationDto;
 import swyp.swyp6_team7.notification.dto.TravelCommentNotificationDto;
@@ -19,6 +21,8 @@ import swyp.swyp6_team7.notification.util.NotificationMaker;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +35,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final TravelRepository travelRepository;
     private final EnrollmentRepository enrollmentRepository;
+    private final BookmarkRepository bookmarkRepository;
 
 
     @Async
@@ -62,13 +67,41 @@ public class NotificationService {
 
     @Async
     public void createCompanionClosedNotification(Travel targetTravel) {
-        Notification hostNotification = NotificationMaker.travelCompanionClosedMessageToHost(targetTravel);
-        notificationRepository.save(hostNotification);
+        List<Notification> createdNotifications = new ArrayList<>();
 
-        List<Notification> notificationsToCompanions = targetTravel.getCompanions().stream()
-                .map(companion -> NotificationMaker.travelClosedMessageToCompanions(targetTravel, companion.getUserNumber()))
+        // to 주최자
+        Notification hostNotification = NotificationMaker.travelCompanionClosedMessageToHost(targetTravel);
+        createdNotifications.add(hostNotification);
+
+        // to 참가 확정자
+        List<Integer> companionsNumber = targetTravel.getCompanions().stream()
+                .map(companion -> companion.getUserNumber())
+                .toList();
+        List<Notification> notificationsToCompanions = companionsNumber.stream()
+                .map(userNumber -> NotificationMaker.travelClosedMessageToCompanions(targetTravel, userNumber))
                 .collect(Collectors.toList());
-        notificationRepository.saveAll(notificationsToCompanions);
+        createdNotifications.addAll(notificationsToCompanions);
+
+        // to PENDING 신청자
+        List<Integer> pendingUsersNumber = enrollmentRepository.findUserNumbersByTravelNumberAndStatus(targetTravel.getNumber(), EnrollmentStatus.PENDING);
+        List<Notification> notificationsToPendingUser = pendingUsersNumber.stream()
+                .map(userNumber -> NotificationMaker.travelClosedMessageToPendingUser(targetTravel, userNumber))
+                .collect(Collectors.toList());
+        createdNotifications.addAll(notificationsToPendingUser);
+
+        // to 즐겨찾기(북마크) 사용자
+        List<Integer> bookmarkedUsersNumber = bookmarkRepository.findUserNumberByTravelNumber(targetTravel.getNumber())
+                        .stream().collect(Collectors.toList());
+        bookmarkedUsersNumber.removeAll(new HashSet<>(companionsNumber));
+        bookmarkedUsersNumber.removeAll(new HashSet<>(pendingUsersNumber));
+
+        List<Notification> notificationsToBookmarkedUsers = bookmarkedUsersNumber.stream()
+                .filter(userNumber -> userNumber != targetTravel.getUserNumber())
+                .map(userNumber -> NotificationMaker.travelClosedMessageToBookmarkedUser(targetTravel, userNumber))
+                .collect(Collectors.toList());
+        createdNotifications.addAll(notificationsToBookmarkedUsers);
+
+        notificationRepository.saveAll(createdNotifications);
     }
 
     @Async

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -67,7 +67,7 @@ public class NotificationMaker {
                 .content(NotificationMessageType.TRAVEL_COMPANION_CLOSED_HOST.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
-                .travelDueDate(null)
+                .travelDueDate(targetTravel.getDueDate())
                 .travelHost(true)
                 .isRead(false)
                 .build();
@@ -76,11 +76,37 @@ public class NotificationMaker {
     public static Notification travelClosedMessageToCompanions(Travel targetTravel, int receiveUserNumber) {
         return TravelNotification.builder()
                 .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_CLOSED.getTitle())
-                .content(NotificationMessageType.TRAVEL_CLOSED.getContent(targetTravel.getTitle()))
+                .title(NotificationMessageType.TRAVEL_CLOSED_COMPANION.getTitle())
+                .content(NotificationMessageType.TRAVEL_CLOSED_COMPANION.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
-                .travelDueDate(null)
+                .travelDueDate(targetTravel.getDueDate())
+                .travelHost(false)
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelClosedMessageToPendingUser(Travel targetTravel, int receiveUserNumber) {
+        return TravelNotification.builder()
+                .receiverNumber(receiveUserNumber)
+                .title(NotificationMessageType.TRAVEL_CLOSED_PENDING.getTitle())
+                .content(NotificationMessageType.TRAVEL_CLOSED_PENDING.getContent(targetTravel.getTitle()))
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
+                .travelHost(false)
+                .isRead(false)
+                .build();
+    }
+
+    public static Notification travelClosedMessageToBookmarkedUser(Travel targetTravel, int receiveUserNumber) {
+        return TravelNotification.builder()
+                .receiverNumber(receiveUserNumber)
+                .title(NotificationMessageType.TRAVEL_CLOSED_BOOKMARKED.getTitle())
+                .content(NotificationMessageType.TRAVEL_CLOSED_BOOKMARKED.getContent(targetTravel.getTitle()))
+                .travelNumber(targetTravel.getNumber())
+                .travelTitle(targetTravel.getTitle())
+                .travelDueDate(targetTravel.getDueDate())
                 .travelHost(false)
                 .isRead(false)
                 .build();

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -16,6 +16,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
+                .travelHost(true)
                 .isRead(false)
                 .build();
     }
@@ -28,6 +29,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
+                .travelHost(false)
                 .isRead(false)
                 .build();
     }
@@ -40,6 +42,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
+                .travelHost(false)
                 .isRead(false)
                 .build();
     }
@@ -52,6 +55,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
+                .travelHost(false)
                 .isRead(false)
                 .build();
     }
@@ -64,6 +68,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(null)
+                .travelHost(true)
                 .isRead(false)
                 .build();
     }
@@ -76,6 +81,7 @@ public class NotificationMaker {
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(null)
+                .travelHost(false)
                 .isRead(false)
                 .build();
     }

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -9,62 +9,42 @@ import swyp.swyp6_team7.travel.domain.Travel;
 public class NotificationMaker {
 
     public static Notification travelEnrollmentMessageToHost(Travel targetTravel) {
-        return TravelNotification.builder()
-                .receiverNumber(targetTravel.getUserNumber())
-                .title(NotificationMessageType.TRAVEL_ENROLL_HOST.getTitle())
-                .content(NotificationMessageType.TRAVEL_ENROLL_HOST.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(true)
-                .isRead(false)
-                .build();
+        return createHostTravelNotification(NotificationMessageType.TRAVEL_ENROLL_HOST, targetTravel);
     }
 
     public static Notification travelEnrollmentMessage(Travel targetTravel, int receiveUserNumber) {
-        return TravelNotification.builder()
-                .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_ENROLL.getTitle())
-                .content(NotificationMessageType.TRAVEL_ENROLL.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(false)
-                .isRead(false)
-                .build();
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_ENROLL, targetTravel, receiveUserNumber);
     }
 
     public static Notification travelAcceptMessage(Travel targetTravel, int receiveUserNumber) {
-        return TravelNotification.builder()
-                .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_ACCEPT.getTitle())
-                .content(NotificationMessageType.TRAVEL_ACCEPT.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(false)
-                .isRead(false)
-                .build();
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_ACCEPT, targetTravel, receiveUserNumber);
     }
 
     public static Notification travelRejectMessage(Travel targetTravel, int receiveUserNumber) {
-        return TravelNotification.builder()
-                .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_REJECT.getTitle())
-                .content(NotificationMessageType.TRAVEL_REJECT.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(false)
-                .isRead(false)
-                .build();
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_REJECT, targetTravel, receiveUserNumber);
     }
 
     public static Notification travelCompanionClosedMessageToHost(Travel targetTravel) {
+        return createHostTravelNotification(NotificationMessageType.TRAVEL_COMPANION_CLOSED_HOST, targetTravel);
+    }
+
+    public static Notification travelClosedMessageToCompanions(Travel targetTravel, int receiveUserNumber) {
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_CLOSED_COMPANION, targetTravel, receiveUserNumber);
+    }
+
+    public static Notification travelClosedMessageToPendingUser(Travel targetTravel, int receiveUserNumber) {
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_CLOSED_PENDING, targetTravel, receiveUserNumber);
+    }
+
+    public static Notification travelClosedMessageToBookmarkedUser(Travel targetTravel, int receiveUserNumber) {
+        return createCommonTravelNotification(NotificationMessageType.TRAVEL_CLOSED_BOOKMARKED, targetTravel, receiveUserNumber);
+    }
+
+    private static TravelNotification createHostTravelNotification(NotificationMessageType messageType, Travel targetTravel) {
         return TravelNotification.builder()
                 .receiverNumber(targetTravel.getUserNumber())
-                .title(NotificationMessageType.TRAVEL_COMPANION_CLOSED_HOST.getTitle())
-                .content(NotificationMessageType.TRAVEL_COMPANION_CLOSED_HOST.getContent(targetTravel.getTitle()))
+                .title(messageType.getTitle())
+                .content(messageType.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())
@@ -73,37 +53,11 @@ public class NotificationMaker {
                 .build();
     }
 
-    public static Notification travelClosedMessageToCompanions(Travel targetTravel, int receiveUserNumber) {
+    private static TravelNotification createCommonTravelNotification(NotificationMessageType messageType, Travel targetTravel, int receiveUserNumber) {
         return TravelNotification.builder()
                 .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_CLOSED_COMPANION.getTitle())
-                .content(NotificationMessageType.TRAVEL_CLOSED_COMPANION.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(false)
-                .isRead(false)
-                .build();
-    }
-
-    public static Notification travelClosedMessageToPendingUser(Travel targetTravel, int receiveUserNumber) {
-        return TravelNotification.builder()
-                .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_CLOSED_PENDING.getTitle())
-                .content(NotificationMessageType.TRAVEL_CLOSED_PENDING.getContent(targetTravel.getTitle()))
-                .travelNumber(targetTravel.getNumber())
-                .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
-                .travelHost(false)
-                .isRead(false)
-                .build();
-    }
-
-    public static Notification travelClosedMessageToBookmarkedUser(Travel targetTravel, int receiveUserNumber) {
-        return TravelNotification.builder()
-                .receiverNumber(receiveUserNumber)
-                .title(NotificationMessageType.TRAVEL_CLOSED_BOOKMARKED.getTitle())
-                .content(NotificationMessageType.TRAVEL_CLOSED_BOOKMARKED.getContent(targetTravel.getTitle()))
+                .title(messageType.getTitle())
+                .content(messageType.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
                 .travelDueDate(targetTravel.getDueDate())

--- a/src/test/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepositoryTest.java
@@ -38,6 +38,24 @@ public class BookmarkRepositoryTest {
         assertThat(bookmarks).hasSize(2);
     }
 
+    @DisplayName("특정 여행에 북마크한 사용자의 번호 리스트 조회 테스트")
+    @Test
+    void findUserNumberByTravelNumber() {
+        // given
+        int travelNumber = 100;
+        Bookmark bookmark1 = new Bookmark(1, travelNumber, LocalDateTime.of(2024, 11, 22, 12, 0));
+        Bookmark bookmark2 = new Bookmark(2, travelNumber, LocalDateTime.of(2024, 11, 22, 0, 0));
+        Bookmark bookmark3 = new Bookmark(3, 101, LocalDateTime.of(2024, 11, 22, 0, 0));
+        bookmarkRepository.saveAll(List.of(bookmark1, bookmark2, bookmark3));
+
+        // when
+        List<Integer> bookmarkedUsersNumber = bookmarkRepository.findUserNumberByTravelNumber(travelNumber);
+
+        // then
+        assertThat(bookmarkedUsersNumber).hasSize(2)
+                .containsExactlyInAnyOrder(1, 2);
+    }
+
     @Test
     @DisplayName("사용자 번호로 북마크 개수 조회 테스트")
     void testCountByUserNumber() {
@@ -52,6 +70,7 @@ public class BookmarkRepositoryTest {
         // then
         assertThat(count).isEqualTo(2);
     }
+
     @Test
     @DisplayName("특정 여행 게시물의 북마크 개수를 조회한다")
     void testCountByTravelNumber() {
@@ -86,6 +105,7 @@ public class BookmarkRepositoryTest {
         assertThat(oldestBookmarks).hasSize(2);
         assertThat(oldestBookmarks.get(0)).isEqualTo(bookmark1);
     }
+
     @Test
     @DisplayName("특정 사용자가 특정 여행을 북마크했는지 확인한다")
     void testExistsByUserNumberAndTravelNumber() {

--- a/src/test/java/swyp/swyp6_team7/config/SyncTaskExecutor.java
+++ b/src/test/java/swyp/swyp6_team7/config/SyncTaskExecutor.java
@@ -1,0 +1,11 @@
+package swyp.swyp6_team7.config;
+
+import org.springframework.core.task.TaskExecutor;
+
+public class SyncTaskExecutor implements TaskExecutor {
+
+    @Override
+    public void execute(Runnable task) {
+        task.run();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/config/SynchronousTaskExecutorConfig.java
+++ b/src/test/java/swyp/swyp6_team7/config/SynchronousTaskExecutorConfig.java
@@ -1,0 +1,15 @@
+package swyp.swyp6_team7.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+@TestConfiguration
+public class SynchronousTaskExecutorConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        return new SyncTaskExecutor();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
@@ -114,6 +114,32 @@ class EnrollmentCustomRepositoryImplTest {
                 );
     }
 
+    @DisplayName("findUserNumbers: 여행 번호와 신청 상태가 주어질 때, 해당하는 신청의 사용자 번호 목록을 가져온다.")
+    @Test
+    void findUserNumbersByTravelNumberAndStatus() {
+        // given
+        Users user1 = userRepository.save(createUser("user1"));
+        Users user2 = userRepository.save(createUser("user2"));
+        Users user3 = userRepository.save(createUser("user3"));
+
+        Location location = locationRepository.save(createLocation());
+        Travel travel = travelRepository.save(
+                createTravel(3, 2, location, LocalDate.of(2024, 11, 12), TravelStatus.IN_PROGRESS)
+        );
+
+        Enrollment enrollment1 = createEnrollment(travel.getNumber(), user1.getUserNumber(), EnrollmentStatus.PENDING);
+        Enrollment enrollment2 = createEnrollment(travel.getNumber(), user2.getUserNumber(), EnrollmentStatus.ACCEPTED);
+        Enrollment enrollment3 = createEnrollment(travel.getNumber(), user3.getUserNumber(), EnrollmentStatus.REJECTED);
+        enrollmentRepository.saveAll(List.of(enrollment1, enrollment2, enrollment3));
+
+        // when
+        List<Integer> userNumbers = enrollmentRepository.findUserNumbersByTravelNumberAndStatus(travel.getNumber(), EnrollmentStatus.PENDING);
+
+        // then
+        assertThat(userNumbers).hasSize(1)
+                .contains(user1.getUserNumber());
+    }
+
     private Enrollment createEnrollment(int travelNumber, int userNumber, EnrollmentStatus status) {
         return Enrollment.builder()
                 .travelNumber(travelNumber)

--- a/src/test/java/swyp/swyp6_team7/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,100 @@
+package swyp.swyp6_team7.notification.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import swyp.swyp6_team7.mock.WithMockCustomUser;
+import swyp.swyp6_team7.notification.dto.NotificationDto;
+import swyp.swyp6_team7.notification.dto.TravelNotificationDto;
+import swyp.swyp6_team7.notification.entity.Notification;
+import swyp.swyp6_team7.notification.entity.TravelNotification;
+import swyp.swyp6_team7.notification.service.NotificationService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @DisplayName("getNotifications: 사용자의 알림 목록을 조회할 수 있다.")
+    @WithMockCustomUser
+    @Test
+    void getNotificationsByUser() throws Exception {
+        // given
+        Notification notification = Notification.builder()
+                .receiverNumber(1)
+                .title("알림")
+                .content("내용")
+                .createdAt(LocalDateTime.of(2024, 11, 20, 0, 0))
+                .isRead(false)
+                .build();
+        NotificationDto notificationDto1 = new NotificationDto(notification);
+
+        TravelNotification travelNotification = TravelNotification.builder()
+                .receiverNumber(1)
+                .title("여행 알림")
+                .content("내용")
+                .createdAt(LocalDateTime.of(2024, 11, 19, 0, 0))
+                .isRead(true)
+                .travelNumber(1)
+                .travelTitle("여행 제목")
+                .travelDueDate(LocalDate.of(2024, 11, 21))
+                .travelHost(true)
+                .build();
+        NotificationDto notificationDto2 = new TravelNotificationDto(travelNotification);
+
+        List<NotificationDto> notifications = Arrays.asList(notificationDto1, notificationDto2);
+        Page<NotificationDto> result = new PageImpl<>(notifications, PageRequest.of(0, 5), notifications.size());
+
+        given(notificationService.getNotificationsByUser(any(PageRequest.class), anyInt()))
+                .willReturn(result);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/notifications"));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("알림"))
+                .andExpect(jsonPath("$.content[0].content").value("내용"))
+                .andExpect(jsonPath("$.content[0].createdAt").value("2024-11-20 00:00"))
+                .andExpect(jsonPath("$.content[0].isRead").value(false))
+                .andExpect(jsonPath("$.content[1].title").value("여행 알림"))
+                .andExpect(jsonPath("$.content[1].content").value("내용"))
+                .andExpect(jsonPath("$.content[1].createdAt").value("2024-11-19 00:00"))
+                .andExpect(jsonPath("$.content[1].isRead").value(true))
+                .andExpect(jsonPath("$.content[1].travelNumber").value(1))
+                .andExpect(jsonPath("$.content[1].travelTitle").value("여행 제목"))
+                .andExpect(jsonPath("$.content[1].travelDueDate").value("2024-11-21"))
+                .andExpect(jsonPath("$.content[1].travelHostUser").value(true));
+    }
+
+}

--- a/src/test/java/swyp/swyp6_team7/notification/service/NotificationServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/service/NotificationServiceTest.java
@@ -1,0 +1,144 @@
+package swyp.swyp6_team7.notification.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
+import swyp.swyp6_team7.companion.domain.Companion;
+import swyp.swyp6_team7.config.SynchronousTaskExecutorConfig;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
+import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
+import swyp.swyp6_team7.notification.repository.NotificationRepository;
+import swyp.swyp6_team7.travel.domain.Travel;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+@Import(SynchronousTaskExecutorConfig.class)
+@SpringBootTest
+class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private EnrollmentRepository enrollmentRepository;
+
+    @MockBean
+    private BookmarkRepository bookmarkRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("enrollNotification: 주어지는 사용자 번호와 여행 주최자에 대해 신청 생성 알림을 생성한다.")
+    @Test
+    void createEnrollNotification() {
+        // given
+        Travel targetTravel = createTravel(1);
+        int enrollmentUserNumber = 2;
+
+        // when
+        notificationService.createEnrollNotification(targetTravel, enrollmentUserNumber);
+
+        // then
+        assertThat(notificationRepository.findAll()).hasSize(2)
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .containsExactlyInAnyOrder(
+                        tuple(1, "여행 신청 알림", "[여행Title]에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.", false, true, 10, "여행Title", LocalDate.of(2024, 11, 16)),
+                        tuple(2, "참가 신청 알림", "[여행Title]에 참가 신청이 완료되었어요. 주최자가 참가를 확정하면 알려드릴게요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16))
+                );
+    }
+    
+    @DisplayName("acceptNotification: 주어지는 사용자 번호에 대해 신청 수락 알림을 생성한다.")
+    @Test
+    void createAcceptNotification() {
+        // given
+        Travel targetTravel = createTravel(1);
+        int enrollmentUserNumber = 2;
+    
+        // when
+        notificationService.createAcceptNotification(targetTravel, enrollmentUserNumber);
+    
+        // then
+        assertThat(notificationRepository.findAll()).hasSize(1)
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .contains(tuple(2, "참가 확정 알림", "[여행Title]에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)));
+    }
+
+    @DisplayName("rejectNotification: 주어지는 사용자 번호에 대해 신청 거절 알림을 생성한다.")
+    @Test
+    void createRejectNotification() {
+        // given
+        Travel targetTravel = createTravel(1);
+        int enrollmentUserNumber = 2;
+
+        // when
+        notificationService.createRejectNotification(targetTravel, enrollmentUserNumber);
+
+        // then
+        assertThat(notificationRepository.findAll()).hasSize(1)
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .contains(tuple(2, "참가 거절 알림", "[여행Title]에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)));
+    }
+
+    @DisplayName("companionClosedNotification: 주최자, 참여자, pending 상태의 신청자, 즐겨찾기 사용자에 대해 인원 마감 알림을 생성한다.")
+    @Test
+    void createCompanionClosedNotification() {
+        // given
+        Travel targetTravel = createTravel(1);
+        createCompanion(targetTravel, 2);
+
+        given(enrollmentRepository.findUserNumbersByTravelNumberAndStatus(anyInt(), any(EnrollmentStatus.class)))
+                .willReturn(Arrays.asList(3));
+        given(bookmarkRepository.findUserNumberByTravelNumber(anyInt()))
+                .willReturn(Arrays.asList(1, 2, 3, 4));
+
+        // when
+        notificationService.createCompanionClosedNotification(targetTravel);
+
+        // then
+        assertThat(notificationRepository.findAll()).hasSize(4)
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .containsExactlyInAnyOrder(
+                        tuple(1, "모집 마감 알림", "[여행Title]의 인원이 가득 차 모집이 마감되었어요.", false, true, 10, "여행Title", LocalDate.of(2024, 11, 16)),
+                        tuple(2, "모집 마감 알림", "참가하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)),
+                        tuple(3, "모집 마감 알림", "참가 신청하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)),
+                        tuple(4, "모집 마감 알림", "즐겨찾기하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16))
+                );
+    }
+
+
+    private Companion createCompanion(Travel travel, int userNumber) {
+        return Companion.builder()
+                .travel(travel)
+                .userNumber(userNumber)
+                .build();
+    }
+
+    private Travel createTravel(int hostUserNumber) {
+        return Travel.builder()
+                .number(10)
+                .userNumber(hostUserNumber)
+                .title("여행Title")
+                .maxPerson(2)
+                .dueDate(LocalDate.of(2024, 11, 16))
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🔗 Issue Number
feat: 여행 참가 인원 마감 알림 #143

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
* 인원 마감 알림 수신자 대상 추가
  - 기존: 주최자, 참가 확정자(companion)
  - 현재: 주최자, 참가 확정자 + pending상태의 신청자, 해당 여행에 즐겨찾기(북마크) 한 사용자
  - 즐겨찾기 사용자의 경우, 주최자/참가확정자/신청자인 경우를 제외해 중복 알림을 방지함
* NotificationService 테스트코드 작성
  - `@Async` 메서드를 테스트하기 위해 테스트 Config 디렉토리에 `SynchronousTaskExecutorConfig` 추가
* NotificationMaker 여행 알림 주최자용, 일반용 메서드 분리
  - 주최자용: receiverNumber가 여행의 userNumber, travelHost의 값이 true



## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
