### PR TITLE
refactor: 카카오 로그인 시 이메일 임시 값에 랜덤한 문자열 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/auth/service/KakaoService.java
+++ b/src/main/java/swyp/swyp6_team7/auth/service/KakaoService.java
@@ -137,7 +137,7 @@ public class KakaoService {
 
     @Transactional
     private Users saveSocialUser(Map<String, String> userInfo) {
-        String email = userInfo.getOrDefault("email", "unknown@example.com");
+        String email = userInfo.getOrDefault("email", "unknown@" + UUID.randomUUID().toString().substring(0, 8) + ".email");
         String socialLoginId = userInfo.get("socialLoginId");
         String nickname = userInfo.get("nickname");
 


### PR DESCRIPTION
## 🔗 Issue Number

> #5 

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용

> 카카오 로그인 시 사용자의 이메일을 받기 전 임시로 unkwown@example.com값이 들어가지만 이 값이 Unique 제약조건에 걸리기 때문에 이메일에 대한 임시값을 다음과 같이 변경함.
"unknown@" + UUID.randomUUID().toString().substring(0, 8) + ".email"




## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
