### PR TITLE
feat: 여행 관련 API 비로그인 사용자 로직 구현

### DIFF
--- a/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import swyp.swyp6_team7.bookmark.entity.Bookmark;
 
 import java.util.List;
+import java.util.Map;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
     List<Bookmark> findByUserNumber(Integer userNumber);
@@ -25,6 +26,9 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
     List<Bookmark> findBookmarksByUserNumber(@Param("userNumber") Integer userNumber);
 
     boolean existsByUserNumberAndTravelNumber(Integer userNumber, Integer travelNumber);
+
+    @Query("SELECT b.travelNumber FROM Bookmark b WHERE b.userNumber = :userNumber and b.travelNumber IN :travelNumbers")
+    List<Integer> findExistingBookmarkedTravelNumbers(@Param("userNumber") Integer userNumber, @Param("travelNumbers") List<Integer> travelNumbers);
 
     int deleteByUserNumberAndTravelNumber(Integer userNumber, Integer travelNumber);
 

--- a/src/main/java/swyp/swyp6_team7/bookmark/service/BookmarkService.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/service/BookmarkService.java
@@ -19,7 +19,9 @@ import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static swyp.swyp6_team7.bookmark.dto.BookmarkResponse.*;
@@ -143,6 +145,17 @@ public class BookmarkService {
         return bookmarkRepository.findBookmarksByUserNumber(userNumber).stream()
                 .map(Bookmark::getTravelNumber)
                 .collect(Collectors.toList());
+    }
+
+    public Map<Integer, Boolean> getBookmarkExistenceByTravelNumbers(int userNumber, List<Integer> travelNumbers) {
+        List<Integer> bookmarkedTravels = bookmarkRepository.findExistingBookmarkedTravelNumbers(userNumber, travelNumbers);
+
+        HashMap<Integer, Boolean> resultMap = new HashMap<Integer, Boolean>();
+        for (Integer travelNumber : travelNumbers) {
+            resultMap.put(travelNumber, bookmarkedTravels.contains(travelNumber));
+        }
+
+        return resultMap;
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/enrollment/domain/Enrollment.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/domain/Enrollment.java
@@ -71,4 +71,15 @@ public class Enrollment {
         this.status = EnrollmentStatus.REJECTED;
     }
 
+    @Override
+    public String toString() {
+        return "Enrollment{" +
+                "number=" + number +
+                ", userNumber=" + userNumber +
+                ", travelNumber=" + travelNumber +
+                ", createdAt=" + createdAt +
+                ", message='" + message + '\'' +
+                ", status=" + status +
+                '}';
+    }
 }

--- a/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepository.java
@@ -12,6 +12,8 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, E
 
     long countByTravelNumberAndStatus(int travelNumber, EnrollmentStatus status);
 
+    Enrollment findTopByUserNumberAndTravelNumberOrderByCreatedAtDesc(int userNumber, int travelNumber);
+
     Enrollment findOneByUserNumberAndTravelNumber(int userNumber, int travelNumber);
 
     boolean existsByUserNumberAndTravelNumber(int userNumber, int travelNumber);

--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/travel/detail/**",
                                 "/api/travels/recent",
+                                "/api/travels/recommend",
                                 "/api/travels/search"
                         ).permitAll()
 

--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                         // 비회원(비로그인) 관련 권한 설정
                         .requestMatchers(
                                 "/api/travel/detail/**",
-                                "/api/travels/recent"
+                                "/api/travels/recent",
+                                "/api/travels/search"
                         ).permitAll()
 
                         // 기타 경로

--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -46,7 +46,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/logout").authenticated()
 
                         // 비회원(비로그인) 관련 권한 설정
-                        .requestMatchers("/api/travel/detail/**").permitAll()
+                        .requestMatchers(
+                                "/api/travel/detail/**",
+                                "/api/travels/recent"
+                        ).permitAll()
 
                         // 기타 경로
                         .requestMatchers(
@@ -57,7 +60,7 @@ public class SecurityConfig {
                                 "/api/social/login",
                                 "/api/social/kakao/complete-signup",
                                 "/api/social/google/complete-signup",
-                                "/api/login/oauth/kakao/**","/api/login/oauth/naver/**","/api/login/oauth/google/**",
+                                "/api/login/oauth/kakao/**", "/api/login/oauth/naver/**", "/api/login/oauth/google/**",
                                 "/error",
                                 "/api/users-email",
                                 "/actuator/health", // Health check endpoint permission

--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -45,6 +45,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/profile/**").authenticated()
                         .requestMatchers("/api/logout").authenticated()
 
+                        // 비회원(비로그인) 관련 권한 설정
+                        .requestMatchers("/api/travel/detail/**").permitAll()
+
                         // 기타 경로
                         .requestMatchers(
                                 "/api/admins/new",

--- a/src/main/java/swyp/swyp6_team7/member/util/MemberAuthorizeUtil.java
+++ b/src/main/java/swyp/swyp6_team7/member/util/MemberAuthorizeUtil.java
@@ -13,7 +13,17 @@ public class MemberAuthorizeUtil {
 
     public static Integer getLoginUserNumber() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return userDetails.getUserNumber();
+
+        // 로그인 한 경우
+        if (authentication != null && authentication.isAuthenticated()) {
+            if (authentication.getPrincipal() instanceof CustomUserDetails) {
+                CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+                Integer userNumber = userDetails.getUserNumber();
+                return userNumber;
+            }
+        }
+
+        // 로그인 하지 않은 경우
+        return null;
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -10,12 +10,12 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import swyp.swyp6_team7.member.util.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelCreateResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
+import swyp.swyp6_team7.travel.dto.response.TravelUpdateResponse;
 import swyp.swyp6_team7.travel.service.TravelService;
 
 @Slf4j
@@ -58,7 +58,7 @@ public class TravelController {
     }
 
     @PutMapping("/api/travel/{travelNumber}")
-    public ResponseEntity<TravelDetailResponse> update(
+    public ResponseEntity<TravelUpdateResponse> update(
             @PathVariable("travelNumber") int travelNumber,
             @RequestBody TravelUpdateRequest request
     ) {
@@ -68,9 +68,8 @@ public class TravelController {
         Travel updatedTravel = travelService.update(travelNumber, request, loginUserNumber);
         logger.info("Travel 수정 요청 - userId: {}, updatedTravel: {}", loginUserNumber, updatedTravel);
 
-        // TODO: 여행 번호만 전달
         return ResponseEntity.status(HttpStatus.OK)
-                .body(travelService.getDetailsByNumber(travelNumber));
+                .body(new TravelUpdateResponse(updatedTravel.getNumber()));
     }
 
     @DeleteMapping("/api/travel/{travelNumber}")

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -14,6 +14,7 @@ import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
 import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
+import swyp.swyp6_team7.travel.dto.response.TravelCreateResponse;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.service.TravelService;
 
@@ -26,16 +27,15 @@ public class TravelController {
     private final TravelService travelService;
 
     @PostMapping("/api/travel")
-    public ResponseEntity<TravelDetailResponse> create(@RequestBody @Validated TravelCreateRequest request) {
+    public ResponseEntity<TravelCreateResponse> create(@RequestBody @Validated TravelCreateRequest request) {
         int loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
         logger.info("Travel 생성 요청 - userId: {}", loginUserNumber);
 
         Travel createdTravel = travelService.create(request, loginUserNumber);
         logger.info("Travel 생성 완료 - userId: {}, createdTravel: {}", loginUserNumber, createdTravel);
 
-        // TODO: 여행 번호만 전달
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(travelService.getDetailsByNumber(createdTravel.getNumber()));
+                .body(new TravelCreateResponse(createdTravel.getNumber()));
     }
 
     @GetMapping("/api/travel/detail/{travelNumber}")

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -43,8 +43,19 @@ public class TravelHomeController {
         Integer loginUserNumber = MemberAuthorizeUtil.getLoginUserNumber();
         LocalDate requestDate = LocalDate.now();
 
+        // 로그인 사용자: 태그 기반 추천 + 마감일이 빠른 순서 + title
+        if (loginUserNumber != null) {
+            Page<TravelRecommendResponse> result = travelHomeService
+                    .getRecommendTravelsByMember(PageRequest.of(page, size), loginUserNumber, requestDate)
+                    .map(TravelRecommendResponse::new);
+
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(result);
+        }
+
+        // 비로그인 사용자: 북마크 개수 기반 추천 + title
         Page<TravelRecommendResponse> result = travelHomeService
-                .getRecommendTravelsByUser(PageRequest.of(page, size), loginUserNumber, requestDate)
+                .getRecommendTravelsByNonMember(PageRequest.of(page, size), requestDate)
                 .map(TravelRecommendResponse::new);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelHomeController.java
@@ -21,7 +21,6 @@ public class TravelHomeController {
 
     private final TravelHomeService travelHomeService;
 
-
     @GetMapping("/api/travels/recent")
     public ResponseEntity<Page<TravelRecentDto>> getRecentlyCreatedTravels(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailDto.java
@@ -4,6 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import swyp.swyp6_team7.member.entity.AgeGroup;
 import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
 
 import java.util.List;
 
@@ -16,12 +17,11 @@ public class TravelDetailDto {
     private String hostAgeGroup;
     private int companionCount;
     private List<String> tags;
-    private boolean bookmarked;
 
     @QueryProjection
     public TravelDetailDto(
             Travel travel, int hostNumber, String hostName, AgeGroup hostAgeGroup,
-            int companionCount, List<String> tags, boolean isBookmarked
+            int companionCount, List<String> tags
     ) {
         this.travel = travel;
         this.hostNumber = hostNumber;
@@ -29,7 +29,10 @@ public class TravelDetailDto {
         this.hostAgeGroup = hostAgeGroup.getValue();
         this.companionCount = companionCount;
         this.tags = tags;
-        this.bookmarked = isBookmarked;
+    }
+
+    public TravelStatus getTravelStatus() {
+        return travel.getStatus();
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailLoginMemberRelatedDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelDetailLoginMemberRelatedDto.java
@@ -1,0 +1,49 @@
+package swyp.swyp6_team7.travel.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import swyp.swyp6_team7.enrollment.domain.Enrollment;
+
+@Getter
+public class TravelDetailLoginMemberRelatedDto {
+
+    private boolean hostUser;       // 주최자 여부
+    private Long enrollmentNumber;       // 신청 번호(없으면 null)
+    private boolean bookmarked;     // 북마크 여부
+
+    @Builder
+    public TravelDetailLoginMemberRelatedDto(boolean isHostUser, Long enrollmentNumber, boolean isBookmarked) {
+        this.hostUser = isHostUser;
+        this.enrollmentNumber = enrollmentNumber;
+        this.bookmarked = isBookmarked;
+    }
+
+    public TravelDetailLoginMemberRelatedDto() {
+        this.hostUser = false;
+        this.enrollmentNumber = null;
+        this.bookmarked = false;
+    }
+
+    public void setHostUserCheckTrue() {
+        this.hostUser = true;
+    }
+
+    public void setEnrollmentNumber(Enrollment enrollment) {
+        if (enrollment != null) {
+            this.enrollmentNumber = enrollment.getNumber();
+        }
+    }
+
+    public void setBookmarkedTrue() {
+        this.bookmarked = true;
+    }
+
+    @Override
+    public String toString() {
+        return "TravelDetailLoginMemberDto{" +
+                "hostUser=" + hostUser +
+                ", enrollmentNumber=" + enrollmentNumber +
+                ", bookmarked=" + bookmarked +
+                '}';
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForMemberDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForMemberDto.java
@@ -1,0 +1,92 @@
+package swyp.swyp6_team7.travel.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swyp.swyp6_team7.travel.domain.Travel;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TravelRecommendForMemberDto {
+
+    private int travelNumber;
+    private String title;
+    private String location;
+    private int userNumber;
+    private String userName;
+    private List<String> tags;
+    private int nowPerson;
+    private int maxPerson;
+    private LocalDateTime createdAt;
+    private LocalDate registerDue;
+    private int preferredNumber;
+    private boolean bookmarked;
+
+    @Builder
+    public TravelRecommendForMemberDto(
+            int travelNumber, String title, String location, int userNumber, String userName,
+            List<String> tags, int nowPerson, int maxPerson,
+            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber, boolean isBookmarked
+    ) {
+        this.travelNumber = travelNumber;
+        this.title = title;
+        this.location = location;
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.tags = tags;
+        this.nowPerson = nowPerson;
+        this.maxPerson = maxPerson;
+        this.createdAt = createdAt;
+        this.registerDue = registerDue;
+        this.preferredNumber = preferredNumber;
+        this.bookmarked = isBookmarked;
+    }
+
+    @QueryProjection
+    public TravelRecommendForMemberDto(
+            Travel travel, int userNumber, String userName,
+            int companionCount, List<String> tags, boolean isBookmarked
+    ) {
+        this.travelNumber = travel.getNumber();
+        this.title = travel.getTitle();
+        this.location = travel.getLocationName();
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.tags = tags;
+        this.nowPerson = companionCount;
+        this.maxPerson = travel.getMaxPerson();
+        this.createdAt = travel.getCreatedAt();
+        this.registerDue = travel.getDueDate();
+        this.bookmarked = isBookmarked;
+    }
+
+    public void updatePreferredNumber(Integer number) {
+        this.preferredNumber = number;
+    }
+
+    @Override
+    public String toString() {
+        return "TravelRecommendDto{" +
+                "travelNumber=" + travelNumber +
+                ", title='" + title + '\'' +
+                ", location='" + location + '\'' +
+                ", userNumber=" + userNumber +
+                ", userName='" + userName + '\'' +
+                ", location='" + location + '\'' +
+                ", tags=" + tags +
+                ", nowPerson=" + nowPerson +
+                ", maxPerson=" + maxPerson +
+                ", createdAt=" + createdAt +
+                ", registerDue=" + registerDue +
+                ", preferredNumber=" + preferredNumber +
+                ", bookmarked=" + bookmarked +
+                '}';
+    }
+}
+

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForNonMemberDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForNonMemberDto.java
@@ -1,7 +1,6 @@
 package swyp.swyp6_team7.travel.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +13,8 @@ import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TravelRecommendDto {
+public class TravelRecommendForNonMemberDto {
 
-    @NotNull
     private int travelNumber;
     private String title;
     private String location;
@@ -27,14 +25,13 @@ public class TravelRecommendDto {
     private int maxPerson;
     private LocalDateTime createdAt;
     private LocalDate registerDue;
-    private int preferredNumber;
-    private boolean bookmarked;
+    private int bookmarkCount;
 
     @Builder
-    public TravelRecommendDto(
+    public TravelRecommendForNonMemberDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber, boolean bookmarked
+            LocalDateTime createdAt, LocalDate registerDue, int bookmarkCount
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -46,14 +43,13 @@ public class TravelRecommendDto {
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
         this.registerDue = registerDue;
-        this.preferredNumber = preferredNumber;
-        this.bookmarked = bookmarked;
+        this.bookmarkCount = bookmarkCount;
     }
 
     @QueryProjection
-    public TravelRecommendDto(
+    public TravelRecommendForNonMemberDto(
             Travel travel, int userNumber, String userName,
-            int companionCount, List<String> tags, boolean isBookmarked
+            int companionCount, List<String> tags, int bookmarkCount
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
@@ -65,30 +61,23 @@ public class TravelRecommendDto {
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();
-        this.bookmarked = isBookmarked;
-    }
-
-    public void updatePreferredNumber(Integer number) {
-        this.preferredNumber = number;
+        this.bookmarkCount = bookmarkCount;
     }
 
     @Override
     public String toString() {
-        return "TravelRecommendDto{" +
+        return "TravelRecommendForNonMemberDto{" +
                 "travelNumber=" + travelNumber +
                 ", title='" + title + '\'' +
                 ", location='" + location + '\'' +
                 ", userNumber=" + userNumber +
                 ", userName='" + userName + '\'' +
-                ", location='" + location + '\'' +
                 ", tags=" + tags +
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", createdAt=" + createdAt +
                 ", registerDue=" + registerDue +
-                ", preferredNumber=" + preferredNumber +
-                ", bookmarked=" + bookmarked +
+                ", bookmarkCount=" + bookmarkCount +
                 '}';
     }
 }
-

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
@@ -20,13 +20,13 @@ import java.util.List;
 public class TravelCreateRequest {
 
     private String locationName;
-    @Size(max = 20)
+    @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
     private String title;
     private String details;
-    @PositiveOrZero
+    @PositiveOrZero(message = "여행 참가 최대 인원은 0보다 작을 수 없습니다.")
     private int maxPerson;
     private String genderType;
-    @FutureOrPresent
+    @FutureOrPresent(message = "여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다.")
     private LocalDate dueDate;
     private String periodType;
     @NotNull

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
@@ -17,13 +17,13 @@ import java.util.List;
 public class TravelUpdateRequest {
 
     private String locationName;
-    @Size(max = 20)
+    @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
     private String title;
     private String details;
-    @PositiveOrZero
+    @PositiveOrZero(message = "여행 참가 최대 인원은 0보다 작을 수 없습니다.")
     private int maxPerson;
     private String genderType;
-    @FutureOrPresent
+    @FutureOrPresent(message = "여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다.")
     private LocalDate dueDate;
     private String periodType;
     @NotNull

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelCreateResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelCreateResponse.java
@@ -1,0 +1,13 @@
+package swyp.swyp6_team7.travel.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class TravelCreateResponse {
+
+    private int travelNumber;
+
+    public TravelCreateResponse(int travelNumber) {
+        this.travelNumber = travelNumber;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -5,8 +5,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.enrollment.domain.Enrollment;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
+import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,17 +37,15 @@ public class TravelDetailResponse {
     private String periodType;
     private List<String> tags;
     private String postStatus;
-    private boolean hostUserCheck;       //주최자 여부
-    private Long enrollmentNumber;       //신청 번호(없으면 null)
-    private boolean bookmarked;     //북마크 여부
+    private TravelDetailLoginMemberRelatedDto loginMemberRelatedInfo; // 로그인 사용자 관련 추가 정보
+
 
     @Builder
     public TravelDetailResponse(
             int travelNumber, int userNumber, String userName, String userAgeGroup, String profileUrl, LocalDateTime createdAt,
             String location, String title, String details, int viewCount, int enrollCount, int bookmarkCount,
             int nowPerson, int maxPerson, String genderType, LocalDate dueDate, String periodType,
-            List<String> tags, String postStatus, boolean hostUserCheck, Long enrollmentNumber,
-            boolean isBookmarked
+            List<String> tags, String postStatus
     ) {
         this.travelNumber = travelNumber;
         this.userNumber = userNumber;
@@ -68,14 +66,10 @@ public class TravelDetailResponse {
         this.periodType = periodType;
         this.tags = tags;
         this.postStatus = postStatus;
-        this.hostUserCheck = hostUserCheck;
-        this.enrollmentNumber = enrollmentNumber;
-        this.bookmarked = isBookmarked;
     }
 
     public TravelDetailResponse(
-            TravelDetailDto travelDetail, String hostProfileImageUrl,
-            int enrollCount, int bookmarkCount
+            TravelDetailDto travelDetail, String hostProfileImageUrl, int enrollCount, int bookmarkCount
     ) {
         this.travelNumber = travelDetail.getTravel().getNumber();
         this.userNumber = travelDetail.getHostNumber();
@@ -96,20 +90,11 @@ public class TravelDetailResponse {
         this.periodType = travelDetail.getTravel().getPeriodType().toString();
         this.tags = travelDetail.getTags();
         this.postStatus = travelDetail.getTravel().getStatus().toString();
-        this.bookmarked = travelDetail.isBookmarked();
+        this.loginMemberRelatedInfo = null;
     }
 
-
-    public void setHostUserCheckTrue() {
-        this.hostUserCheck = true;
-    }
-
-    public void setEnrollmentNumber(Enrollment enrollment) {
-        if (enrollment==null) {
-            this.enrollmentNumber = null;
-        } else {
-            this.enrollmentNumber = enrollment.getNumber();
-        }
+    public void updateLoginMemberRelatedInfo(TravelDetailLoginMemberRelatedDto memberRelatedDto) {
+        this.loginMemberRelatedInfo = memberRelatedDto;
     }
 
     @Override
@@ -134,9 +119,7 @@ public class TravelDetailResponse {
                 ", periodType='" + periodType + '\'' +
                 ", tags=" + tags +
                 ", postStatus='" + postStatus + '\'' +
-                ", hostUserCheck=" + hostUserCheck +
-                ", enrollmentNumber=" + enrollmentNumber +
-                ", bookmarked=" + bookmarked +
+                ", loginMemberRelatedInfo=" + loginMemberRelatedInfo +
                 '}';
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -33,12 +33,11 @@ public class TravelRecentDto {
     private boolean bookmarked;
 
 
-
     @Builder
     public TravelRecentDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue
+            LocalDateTime createdAt, LocalDate registerDue, boolean isBookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -50,12 +49,13 @@ public class TravelRecentDto {
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
         this.registerDue = registerDue;
+        this.bookmarked = isBookmarked;
     }
 
     @QueryProjection
     public TravelRecentDto(
             Travel travel, int userNumber, String userName,
-            int companionCount, List<String> tags, boolean isBookmarked
+            int companionCount, List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
@@ -67,7 +67,11 @@ public class TravelRecentDto {
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();
-        this.bookmarked = isBookmarked;
+        this.bookmarked = false;
+    }
+
+    public void updateBookmarked(Boolean bookmarked) {
+        this.bookmarked = bookmarked;
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
@@ -5,7 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForNonMemberDto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,19 +31,32 @@ public class TravelRecommendResponse {
     private LocalDate registerDue;
     private boolean bookmarked;
 
-    public TravelRecommendResponse(TravelRecommendDto dto) {
+    public TravelRecommendResponse(TravelRecommendForMemberDto dto) {
         this.travelNumber = dto.getTravelNumber();
         this.title = dto.getTitle();
         this.location = dto.getLocation();
         this.userNumber = dto.getUserNumber();
         this.userName = dto.getUserName();
-        this.location = dto.getLocation();
         this.tags = dto.getTags();
         this.nowPerson = dto.getNowPerson();
         this.maxPerson = dto.getMaxPerson();
         this.createdAt = dto.getCreatedAt();
         this.registerDue = dto.getRegisterDue();
         this.bookmarked = dto.isBookmarked();
+    }
+
+    public TravelRecommendResponse(TravelRecommendForNonMemberDto dto) {
+        this.travelNumber = dto.getTravelNumber();
+        this.title = dto.getTitle();
+        this.location = dto.getLocation();
+        this.userNumber = dto.getUserNumber();
+        this.userName = dto.getUserName();
+        this.tags = dto.getTags();
+        this.nowPerson = dto.getNowPerson();
+        this.maxPerson = dto.getMaxPerson();
+        this.createdAt = dto.getCreatedAt();
+        this.registerDue = dto.getRegisterDue();
+        this.bookmarked = false;
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -38,7 +38,7 @@ public class TravelSearchDto {
     public TravelSearchDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int maxPerson, int nowPerson,
-            LocalDateTime createdAt, LocalDate registerDue, String postStatus
+            LocalDateTime createdAt, LocalDate registerDue, String postStatus, boolean isBookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -51,13 +51,14 @@ public class TravelSearchDto {
         this.createdAt = createdAt;
         this.registerDue = registerDue;
         this.postStatus = postStatus;
+        this.bookmarked = isBookmarked;
     }
 
 
     @QueryProjection
     public TravelSearchDto(
             Travel travel, int userNumber, String userName,
-            int companionCount, List<String> tags, boolean isBookmarked
+            int companionCount, List<String> tags
     ) {
         this.travelNumber = travel.getNumber();
         this.title = travel.getTitle();
@@ -70,7 +71,11 @@ public class TravelSearchDto {
         this.createdAt = travel.getCreatedAt();
         this.registerDue = travel.getDueDate();
         this.postStatus = travel.getStatus().getName();
-        this.bookmarked = isBookmarked;
+        this.bookmarked = false;
+    }
+
+    public void updateBookmarked(Boolean bookmarked) {
+        this.bookmarked = bookmarked;
     }
 
     @Override

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelUpdateResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelUpdateResponse.java
@@ -1,0 +1,13 @@
+package swyp.swyp6_team7.travel.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class TravelUpdateResponse {
+
+    private int travelNumber;
+
+    public TravelUpdateResponse(int travelNumber) {
+        this.travelNumber = travelNumber;
+    }
+}

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -19,6 +19,6 @@ public interface TravelCustomRepository {
 
     Page<TravelRecommendDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate);
 
-    Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber);
+    Page<TravelSearchDto> search(TravelSearchCondition condition);
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -15,7 +15,7 @@ public interface TravelCustomRepository {
 
     TravelDetailDto getDetailsByNumber(int travelNumber);
 
-    Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest, Integer loginUserNumber);
+    Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest);
 
     Page<TravelRecommendDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate);
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -3,7 +3,8 @@ package swyp.swyp6_team7.travel.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForNonMemberDto;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
@@ -17,7 +18,9 @@ public interface TravelCustomRepository {
 
     Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest);
 
-    Page<TravelRecommendDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate);
+    Page<TravelRecommendForMemberDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate);
+
+    public Page<TravelRecommendForNonMemberDto> findAllSortedByBookmarkNumberAndTitle(PageRequest pageRequest, LocalDate requestDate);
 
     Page<TravelSearchDto> search(TravelSearchCondition condition);
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepository.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 public interface TravelCustomRepository {
 
+    TravelDetailDto getDetailsByNumber(int travelNumber);
+
     Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest, Integer loginUserNumber);
 
     Page<TravelRecommendDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate);
 
     Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber);
-
-    TravelDetailDto getDetailsByNumber(int travelNumber, Integer loginUserNumber);
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -81,7 +81,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
 
     @Override
-    public Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest, Integer loginUserNumber) {
+    public Page<TravelRecentDto> findAllSortedByCreatedAt(PageRequest pageRequest) {
 
         List<Integer> travels = queryFactory
                 .select(travel.number)
@@ -100,8 +100,6 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
-                .leftJoin(bookmark).on(bookmark.userNumber.eq(loginUserNumber)
-                        .and(bookmark.travelNumber.eq(travel.number)))
                 .where(
                         travel.number.in(travels)
                 )
@@ -112,8 +110,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 users.userNumber,
                                 users.userName,
                                 travel.companions.size(),
-                                list(tag.name),
-                                bookmark.bookmarkId.isNotNull()
+                                list(tag.name)
                         ))
                 );
 

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -26,10 +26,7 @@ import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.QTravel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
-import swyp.swyp6_team7.travel.dto.QTravelDetailDto;
-import swyp.swyp6_team7.travel.dto.TravelDetailDto;
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
-import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.*;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.util.TravelSearchConstant;
@@ -118,14 +115,14 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusActivated()
+                        statusInProgress()
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
     }
 
     @Override
-    public Page<TravelRecommendDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate) {
+    public Page<TravelRecommendForMemberDto> findAllByPreferredTags(PageRequest pageRequest, Integer loginUserNumber, List<String> preferredTags, LocalDate requestDate) {
 
         NumberExpression<Long> matchingTagCount = new CaseBuilder()
                 .when(travel.travelTags.isEmpty()).then(Expressions.nullExpression())
@@ -164,8 +161,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
             travelMap.put(tuple.get(travel.number), tuple.get(matchingTagCount).intValue());
         }
 
-
-        List<TravelRecommendDto> content = queryFactory
+        List<TravelRecommendForMemberDto> content = queryFactory
                 .select(travel)
                 .from(travel)
                 .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
@@ -174,10 +170,11 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(bookmark).on(bookmark.userNumber.eq(loginUserNumber)
                         .and(bookmark.travelNumber.eq(travel.number)))
                 .where(
-                        travel.number.in(travels)
+                        travel.number.in(travels),
+                        travel.dueDate.after(requestDate)
                 )
                 .transform(groupBy(travel.number).list(
-                        Projections.constructor(TravelRecommendDto.class,
+                        Projections.constructor(TravelRecommendForMemberDto.class,
                                 travel,
                                 users.userNumber,
                                 users.userName,
@@ -193,12 +190,56 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusActivated()
+                        statusInProgress(),
+                        travel.dueDate.after(requestDate)
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<TravelRecommendForNonMemberDto> findAllSortedByBookmarkNumberAndTitle(PageRequest pageRequest, LocalDate requestDate) {
+
+        NumberExpression<Integer> bookmarkCount = bookmark.bookmarkId.count().intValue();
+
+        List<TravelRecommendForNonMemberDto> content = queryFactory
+                .select(travel)
+                .from(travel)
+                .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
+                .leftJoin(travel.travelTags, travelTag)
+                .leftJoin(travelTag.tag, tag)
+                .leftJoin(bookmark).on(bookmark.travelNumber.eq(travel.number))
+                .where(
+                        statusInProgress(),
+                        travel.dueDate.after(requestDate)
+                )
+                .groupBy(travel.number)
+                .orderBy(
+                        bookmarkCount.desc(),
+                        travel.title.asc()
+                )
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .transform(groupBy(travel.number).list(
+                                Projections.constructor(TravelRecommendForNonMemberDto.class,
+                                        travel,
+                                        users.userNumber,
+                                        users.userName,
+                                        travel.companions.size(),
+                                        list(tag.name),
+                                        bookmarkCount
+                                )));
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(travel.number.countDistinct())
+                .from(travel)
+                .where(
+                        statusInProgress(),
+                        travel.dueDate.after(requestDate)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
+    }
 
     @Override
     public Page<TravelSearchDto> search(TravelSearchCondition condition) {
@@ -246,7 +287,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 users.userName,
                                 travel.companions.size(),
                                 list(tag.name)
-                )));
+                        )));
 
         // 페이징을 위한 countQuery
         JPAQuery<Long> countQuery = queryFactory

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -201,7 +201,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
 
     @Override
-    public Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber) {
+    public Page<TravelSearchDto> search(TravelSearchCondition condition) {
 
         // 조회 조건에 해당하는 Travel의 Number를 가져온다
         List<Integer> travels = queryFactory
@@ -235,7 +235,6 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
-                .leftJoin(bookmark).on(travel.number.eq(bookmark.travelNumber))
                 .where(
                         travel.number.in(travels)
                 )
@@ -246,9 +245,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                                 users.userNumber,
                                 users.userName,
                                 travel.companions.size(),
-                                list(tag.name),
-                                bookmark.userNumber.eq(loginUserNumber))
-                ));
+                                list(tag.name)
+                )));
 
         // 페이징을 위한 countQuery
         JPAQuery<Long> countQuery = queryFactory
@@ -350,7 +348,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
     private List<OrderSpecifier<?>> getOrderSpecifier(TravelSearchSortingType sortingType) {
         if (sortingType == null) {
-            return List.of(travel.dueDate.asc());
+            return List.of(travel.dueDate.asc(), travel.createdAt.desc());
         }
         switch (sortingType) {
             case RECOMMEND:

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -61,15 +61,13 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
     QLocation location = QLocation.location;
 
     @Override
-    public TravelDetailDto getDetailsByNumber(int travelNumber, Integer loginUserNumber) {
+    public TravelDetailDto getDetailsByNumber(int travelNumber) {
         return queryFactory
                 .select(travel)
                 .from(travel)
                 .leftJoin(users).on(travel.userNumber.eq(users.userNumber))
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
-                .leftJoin(bookmark).on(bookmark.userNumber.eq(loginUserNumber)
-                        .and(bookmark.travelNumber.eq(travel.number)))
                 .where(travel.number.eq(travelNumber))
                 .transform(groupBy(travel.number).as(new QTravelDetailDto(
                         travel,
@@ -77,8 +75,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         users.userName,
                         users.userAgeGroup,
                         travel.companions.size(),
-                        list(tag.name),
-                        bookmark.bookmarkId.isNotNull()
+                        list(tag.name)
                 ))).get(travelNumber);
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
@@ -5,9 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swyp.swyp6_team7.bookmark.service.BookmarkService;
 import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
 import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -16,9 +20,26 @@ import swyp.swyp6_team7.travel.repository.TravelRepository;
 public class TravelSearchService {
 
     private final TravelRepository travelRepository;
+    private final BookmarkService bookmarkService;
 
     public Page<TravelSearchDto> search(TravelSearchCondition condition, Integer loginUserNumber) {
-        Page<TravelSearchDto> result = travelRepository.search(condition, loginUserNumber);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
+
+        // 로그인 사용자 좋아요(북마크여부) 처리
+        if (loginUserNumber != null) {
+            List<Integer> travelsNumber = result.getContent().stream()
+                    .map(travelRecentDto -> travelRecentDto.getTravelNumber())
+                    .toList();
+
+            Map<Integer, Boolean> bookmarkedMap = bookmarkService.getBookmarkExistenceByTravelNumbers(loginUserNumber, travelsNumber);
+
+            // 각 여행에 대해 북마크 여부 설정
+            for (TravelSearchDto travelRecentDto : result.getContent()) {
+                Boolean bookmarked = bookmarkedMap.get(travelRecentDto.getTravelNumber());
+                travelRecentDto.updateBookmarked(bookmarked);
+            }
+        }
+
         return result;
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelSearchService.java
@@ -34,9 +34,9 @@ public class TravelSearchService {
             Map<Integer, Boolean> bookmarkedMap = bookmarkService.getBookmarkExistenceByTravelNumbers(loginUserNumber, travelsNumber);
 
             // 각 여행에 대해 북마크 여부 설정
-            for (TravelSearchDto travelRecentDto : result.getContent()) {
-                Boolean bookmarked = bookmarkedMap.get(travelRecentDto.getTravelNumber());
-                travelRecentDto.updateBookmarked(bookmarked);
+            for (TravelSearchDto travelSearchDto : result.getContent()) {
+                Boolean bookmarked = bookmarkedMap.get(travelSearchDto.getTravelNumber());
+                travelSearchDto.updateBookmarked(bookmarked);
             }
         }
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -50,7 +50,6 @@ public class TravelService {
     private final CommentRepository commentRepository;
 
     @Transactional
-
     public Travel create(TravelCreateRequest request, int loginUserNumber) {
 
         Location location = getLocation(request.getLocationName());

--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
@@ -1,13 +1,13 @@
 package swyp.swyp6_team7.travel.util;
 
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
 
 import java.util.Comparator;
 
-public class TravelRecommendComparator implements Comparator<TravelRecommendDto> {
+public class TravelRecommendComparator implements Comparator<TravelRecommendForMemberDto> {
 
     @Override
-    public int compare(TravelRecommendDto o1, TravelRecommendDto o2) {
+    public int compare(TravelRecommendForMemberDto o1, TravelRecommendForMemberDto o2) {
         if (o1.getPreferredNumber() == o2.getPreferredNumber()) {
             if (o1.getRegisterDue().compareTo(o2.getRegisterDue()) == 0) {
                 return o1.getTitle().compareTo(o2.getTitle());

--- a/src/test/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/bookmark/repository/BookmarkRepositoryTest.java
@@ -136,6 +136,23 @@ public class BookmarkRepositoryTest {
 
         // then
         assertThat(deletedCount).isEqualTo(1); // 삭제된 엔티티의 수가 1인지 확인
+    }
 
+    @DisplayName("주어지는 여행 번호 중 사용자가 북마크한 여행 번호만 가져온다.")
+    @Test
+    void findExistingBookmarkedTravelNumbers() {
+        // given
+        int userNumber = 1;
+        List<Integer> travelNumbers = List.of(1, 2, 3, 4);
+        Bookmark bookmark1 = new Bookmark(userNumber, 2, LocalDateTime.now());
+        Bookmark bookmark2 = new Bookmark(userNumber, 3, LocalDateTime.now());
+        bookmarkRepository.saveAll(List.of(bookmark1, bookmark2));
+
+        // when
+        List<Integer> bookmarkedTravels = bookmarkRepository.findExistingBookmarkedTravelNumbers(userNumber, travelNumbers);
+
+        // then
+        assertThat(bookmarkedTravels).hasSize(2)
+                .contains(2, 3);
     }
 }

--- a/src/test/java/swyp/swyp6_team7/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/bookmark/service/BookmarkServiceTest.java
@@ -21,6 +21,7 @@ import swyp.swyp6_team7.travel.repository.TravelRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -187,4 +188,25 @@ public class BookmarkServiceTest {
         // then
         assertThat(responses.getContent()).isEmpty();
     }
+
+    @DisplayName("주어지는 여행 목록에 대한 사용자의 북마크 여부 조회")
+    @Test
+    void getBookmarkExistenceByTravelNumbers() {
+        // given
+        int userNumber = 1;
+        List<Integer> travelNumbers = List.of(1, 2, 3, 4);
+        when(bookmarkRepository.findExistingBookmarkedTravelNumbers(userNumber, travelNumbers))
+                .thenReturn(List.of(2, 3));
+
+        // when
+        Map<Integer, Boolean> bookmarkedMap = bookmarkService.getBookmarkExistenceByTravelNumbers(userNumber, travelNumbers);
+
+        // then
+        assertThat(bookmarkedMap).hasSize(4);
+        assertThat(bookmarkedMap.get(1)).isEqualTo(false);
+        assertThat(bookmarkedMap.get(2)).isEqualTo(true);
+        assertThat(bookmarkedMap.get(3)).isEqualTo(true);
+        assertThat(bookmarkedMap.get(4)).isEqualTo(false);
+    }
+    
 }

--- a/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentRepositoryTest.java
@@ -1,0 +1,59 @@
+package swyp.swyp6_team7.enrollment.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import swyp.swyp6_team7.config.DataConfig;
+import swyp.swyp6_team7.enrollment.domain.Enrollment;
+import swyp.swyp6_team7.enrollment.domain.EnrollmentStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(DataConfig.class)
+@DataJpaTest
+class EnrollmentRepositoryTest {
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+
+    @DisplayName("findTop: 사용자 번호와 여행 번호가 주어질 때, 가장 최신 신청을 조회한다.")
+    @Test
+    void findTopByUserNumberAndTravelNumberOrderByCreatedAtDesc() {
+        // given
+        int userNumber = 1;
+        int travelNumber = 10;
+        Enrollment enrollment1 = enrollmentRepository.save(createEnrollment(userNumber, travelNumber));
+        Enrollment enrollment2 = enrollmentRepository.save(createEnrollment(userNumber, travelNumber));
+
+        // when
+        Enrollment enrollment = enrollmentRepository.findTopByUserNumberAndTravelNumberOrderByCreatedAtDesc(userNumber, travelNumber);
+
+        // then
+        assertThat(enrollment.getNumber()).isEqualTo(enrollment2.getNumber());
+    }
+    
+    @DisplayName("findTop: 사용자 번호와 여행 번호가 주어질 때, 해당하는 신청이 없으면 null을 반환한다.")
+    @Test
+    void findTopByUserNumberAndTravelNumberOrderByCreatedAtDescWhenNotExist() {
+        // given
+        int userNumber = 1;
+        int travelNumber = 10;
+
+        // when
+        Enrollment enrollment = enrollmentRepository.findTopByUserNumberAndTravelNumberOrderByCreatedAtDesc(userNumber, travelNumber);
+
+        // then
+        assertThat(enrollment).isNull();
+    }
+
+    private Enrollment createEnrollment(int userNumber, int travelNumber) {
+        return Enrollment.builder()
+                .userNumber(userNumber)
+                .travelNumber(travelNumber)
+                .status(EnrollmentStatus.PENDING)
+                .build();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -18,6 +18,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
+import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.service.TravelService;
 
@@ -261,6 +262,40 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.loginMemberRelatedInfo.bookmarked").value(true));
         then(travelService).should().getDetailsByNumber(travelNumber);
         then(travelService).should().getTravelDetailMemberRelatedInfo(2, 10, 1, "진행중");
+    }
+
+    @DisplayName("update: 사용자는 여행 콘텐츠를 수정할 수 있다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    public void update() throws Exception {
+        // given
+        TravelUpdateRequest request = TravelUpdateRequest.builder()
+                .locationName("서울")
+                .title("여행 제목")
+                .details("여행 내용")
+                .maxPerson(2)
+                .genderType("모두")
+                .dueDate(LocalDate.now().plusDays(10))
+                .periodType("일주일 이하")
+                .tags(List.of("쇼핑"))
+                .completionStatus(true)
+                .build();
+
+        int travelNumber = 10;
+        Travel updatedTravel = createTravel(travelNumber, 2);
+
+        given(travelService.create(any(TravelCreateRequest.class), anyInt()))
+                .willReturn(updatedTravel);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/travel")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        resultActions.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.travelNumber").value(10));
+        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
     }
 
     private Travel createTravel(int travelNumber, int hostNumber){

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -14,6 +14,7 @@ import swyp.swyp6_team7.member.entity.AgeGroup;
 import swyp.swyp6_team7.mock.WithMockCustomUser;
 import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
@@ -30,8 +31,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -47,8 +47,6 @@ class TravelControllerTest {
     private TravelService travelService;
 
 
-    // todo: 수정 필요
-    /*
     @DisplayName("create: 사용자는 여행 콘텐츠를 생성할 수 있다.")
     @WithMockCustomUser(userNumber = 2)
     @Test
@@ -60,14 +58,17 @@ class TravelControllerTest {
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
-                .dueDate(LocalDate.of(2024, 12, 5))
+                .dueDate(LocalDate.now().plusDays(10))
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
                 .build();
 
+        int travelNumber = 10;
+        Travel createdTravel = createTravel(travelNumber, 2);
+
         given(travelService.create(any(TravelCreateRequest.class), anyInt()))
-                .willReturn();
+                .willReturn(createdTravel);
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/travel")
@@ -76,9 +77,99 @@ class TravelControllerTest {
 
         // then
         resultActions.andExpect(status().isCreated())
-                .andExpect(jsonPath("$.travelNumber").value());
+                .andExpect(jsonPath("$.travelNumber").value(10));
         then(travelService.create(any(TravelCreateRequest.class), eq(2)));
-    }*/
+    }
+
+    @DisplayName("create: 여행 생성 요청 시 title 길이가 20자를 넘으면 예외가 발생한다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    public void createWithValidateTitleLength() throws Exception {
+        // given
+        TravelCreateRequest request = TravelCreateRequest.builder()
+                .locationName("서울")
+                .title("*".repeat(21))
+                .details("여행 내용")
+                .maxPerson(2)
+                .genderType("모두")
+                .dueDate(LocalDate.now().plusDays(10))
+                .periodType("일주일 이하")
+                .tags(List.of("쇼핑"))
+                .completionStatus(true)
+                .build();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/travel")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(content().string("여행 제목은 최대 20자 입니다."));
+        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
+    }
+
+    @DisplayName("create: 여행 생성 요청 시 maxPerson의 값이 0보다 작을 경우 예외가 발생한다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    public void createWithValidateMaxPerson() throws Exception {
+        // given
+        TravelCreateRequest request = TravelCreateRequest.builder()
+                .locationName("서울")
+                .title("여행 제목")
+                .details("여행 내용")
+                .maxPerson(-1)
+                .genderType("모두")
+                .dueDate(LocalDate.now().plusDays(10))
+                .periodType("일주일 이하")
+                .tags(List.of("쇼핑"))
+                .completionStatus(true)
+                .build();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/travel")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(content().string("여행 참가 최대 인원은 0보다 작을 수 없습니다."));
+        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
+    }
+
+    @DisplayName("create: 여행 생성 요청 시 dueDate가 오늘보다 이전인 경우 예외가 발생한다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    public void createWithValidateDueDate() throws Exception {
+        // given
+        TravelCreateRequest request = TravelCreateRequest.builder()
+                .locationName("서울")
+                .title("여행 제목")
+                .details("여행 내용")
+                .maxPerson(2)
+                .genderType("모두")
+                .dueDate(LocalDate.now().minusDays(10))
+                .periodType("일주일 이하")
+                .tags(List.of("쇼핑"))
+                .completionStatus(true)
+                .build();
+
+        int travelNumber = 10;
+        Travel createdTravel = createTravel(travelNumber, 2);
+
+        given(travelService.create(any(TravelCreateRequest.class), anyInt()))
+                .willReturn(createdTravel);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/travel")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(content().string("여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다."));
+        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
+    }
 
 
     @DisplayName("getDetailsByNumber: 비회원(비로그인) 사용자는 여행 상세 정보를 단건 조회할 수 있다.")
@@ -170,6 +261,13 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.loginMemberRelatedInfo.bookmarked").value(true));
         then(travelService).should().getDetailsByNumber(travelNumber);
         then(travelService).should().getTravelDetailMemberRelatedInfo(2, 10, 1, "진행중");
+    }
+
+    private Travel createTravel(int travelNumber, int hostNumber){
+        return Travel.builder()
+                .number(travelNumber)
+                .userNumber(hostNumber)
+                .build();
     }
 
     private TravelDetailResponse createDetailResponse(int travelNumber, int userNumber) {

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -1,40 +1,33 @@
 package swyp.swyp6_team7.travel.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.web.context.WebApplicationContext;
-import swyp.swyp6_team7.location.domain.Location;
-import swyp.swyp6_team7.location.domain.LocationType;
-import swyp.swyp6_team7.location.repository.LocationRepository;
-import swyp.swyp6_team7.member.entity.*;
-import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.member.entity.AgeGroup;
+import swyp.swyp6_team7.mock.WithMockCustomUser;
 import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
-import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 import swyp.swyp6_team7.travel.dto.request.TravelCreateRequest;
-import swyp.swyp6_team7.travel.repository.TravelRepository;
+import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
+import swyp.swyp6_team7.travel.service.TravelService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.UUID;
 
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -50,72 +43,31 @@ class TravelControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private WebApplicationContext context;
-
-    @Autowired
-    private UserDetailsService userDetailsService;
-
-    @Autowired
-    TravelRepository travelRepository;
-
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    LocationRepository locationRepository;
-
-    Users user;
+    @MockBean
+    private TravelService travelService;
 
 
-    @BeforeEach
-    void setSecurityContext() {
-        user = userRepository.save(Users.builder()
-                .userNumber(1)
-                .userEmail("abc@test.com")
-                .userPw("1234")
-                .userName("username")
-                .userGender(Gender.M)
-                .userAgeGroup(AgeGroup.TWENTY)
-                .role(UserRole.USER)
-                .userRegDate(LocalDateTime.now())
-                .userStatus(UserStatus.ABLE)
-                .build());
-
-        var userDetails = userDetailsService.loadUserByUsername(String.valueOf(user.getUserNumber()));
-        SecurityContext context = SecurityContextHolder.getContext();
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
-    }
-
-    @AfterEach
-    void tearDown() {
-        travelRepository.deleteAllInBatch();
-        locationRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-    }
-
-    @DisplayName("create: 사용자는 여행 콘텐츠를 생성할 수 있다")
+    // todo: 수정 필요
+    /*
+    @DisplayName("create: 사용자는 여행 콘텐츠를 생성할 수 있다.")
+    @WithMockCustomUser(userNumber = 2)
     @Test
     public void create() throws Exception {
         // given
-        Location travelLocation = Location.builder()
-                .locationName("서울")
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-
-        LocalDate dueDate = LocalDate.now().plusDays(1);
         TravelCreateRequest request = TravelCreateRequest.builder()
-                .locationName("Seoul")
+                .locationName("서울")
                 .title("여행 제목")
                 .details("여행 내용")
                 .maxPerson(2)
-                .genderType(GenderType.MIXED.toString())
-                .dueDate(dueDate)
-                .periodType(PeriodType.ONE_WEEK.toString())
-                .tags(List.of())
+                .genderType("모두")
+                .dueDate(LocalDate.of(2024, 12, 5))
+                .periodType("일주일 이하")
+                .tags(List.of("쇼핑"))
                 .completionStatus(true)
                 .build();
+
+        given(travelService.create(any(TravelCreateRequest.class), anyInt()))
+                .willReturn();
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/travel")
@@ -124,93 +76,123 @@ class TravelControllerTest {
 
         // then
         resultActions.andExpect(status().isCreated())
-                .andExpect(jsonPath("$.userNumber").value(user.getUserNumber()))
-                .andExpect(jsonPath("$.location").value("Seoul"))
-                .andExpect(jsonPath("$.title").value("여행 제목"))
-                .andExpect(jsonPath("$.details").value("여행 내용"))
-                .andExpect(jsonPath("$.dueDate").value(dueDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
-                .andExpect(jsonPath("$.postStatus").value(TravelStatus.IN_PROGRESS.toString()));
-    }
+                .andExpect(jsonPath("$.travelNumber").value());
+        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
+    }*/
 
 
-    @DisplayName("getDetailsByNumber: 여행 콘텐츠 단건 상세 정보 조회에 성공한다")
+    @DisplayName("getDetailsByNumber: 비회원(비로그인) 사용자는 여행 상세 정보를 단건 조회할 수 있다.")
     @Test
-    //@DirtiesContext
-    public void getDetailsByNumber() throws Exception {
+    public void getDetailsByNumberWhenNonMember() throws Exception {
         // given
-        String url = "/api/travel/detail/{travelNumber}";
-        Travel savedTravel = createTravel(user.getUserNumber(), TravelStatus.IN_PROGRESS);
-        Location travelLocation = Location.builder()
-                .locationName("Jeju-" + UUID.randomUUID().toString())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
+        int travelNumber = 10;
+        int hostNumber = 1;
+        TravelDetailResponse travelDetailResponse = createDetailResponse(travelNumber, hostNumber);
+
+        given(travelService.getDetailsByNumber(anyInt()))
+                .willReturn(travelDetailResponse);
 
         // when
-        ResultActions resultActions = mockMvc.perform(get(url, savedTravel.getNumber()));
-
+        ResultActions resultActions = mockMvc.perform(get("/api/travel/detail/{travelNumber}", travelNumber));
 
         // then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value(savedTravel.getTitle()))
-                .andExpect(jsonPath("$.userNumber").value(user.getUserNumber()));
+                .andExpect(jsonPath("$.travelNumber").value(10))
+                .andExpect(jsonPath("$.userNumber").value(1))
+                .andExpect(jsonPath("$.userName").value("주최자명"))
+                .andExpect(jsonPath("$.userAgeGroup").value("20대"))
+                .andExpect(jsonPath("$.profileUrl").value("https://user-profile-url"))
+                .andExpect(jsonPath("$.createdAt").value("2024-12-06 12:00"))
+                .andExpect(jsonPath("$.location").value("서울"))
+                .andExpect(jsonPath("$.title").value("여행 제목"))
+                .andExpect(jsonPath("$.details").value("여행 상세 내용"))
+                .andExpect(jsonPath("$.viewCount").value(10))
+                .andExpect(jsonPath("$.enrollCount").value(2))
+                .andExpect(jsonPath("$.bookmarkCount").value(5))
+                .andExpect(jsonPath("$.nowPerson").value(1))
+                .andExpect(jsonPath("$.maxPerson").value(4))
+                .andExpect(jsonPath("$.genderType").value("모두"))
+                .andExpect(jsonPath("$.dueDate").value("2024-12-30"))
+                .andExpect(jsonPath("$.tags[0]").value("자연"))
+                .andExpect(jsonPath("$.tags[1]").value("쇼핑"))
+                .andExpect(jsonPath("$.postStatus").value("진행중"))
+                .andExpect(jsonPath("$.loginMemberRelatedInfo").value(nullValue()));
+        then(travelService).should().getDetailsByNumber(travelNumber);
     }
 
-   /* @DisplayName("getDetailsByNumber: 작성자가 아닌 경우 Draft 상태의 콘텐츠 단건 조회를 하면 예외가 발생")
+    @DisplayName("getDetailsByNumber: 로그인 사용자는 여행 상세 단건 정보와 자신과 관련된 추가 정보를 함께 조회할 수 있다.")
+    @WithMockCustomUser(userNumber = 2)
     @Test
-    @DirtiesContext
-    public void getDetailsByNumberDraftException() throws Exception {
+    public void getDetailsByNumberWhenMember() throws Exception {
         // given
-        String url = "/api/travel/detail/{travelNumber}";
-        Travel savedTravel = createTravel(2, TravelStatus.DRAFT);
-        Location travelLocation = Location.builder()
-                .locationName("Seoul-"+System.currentTimeMillis())
-                .locationType(LocationType.DOMESTIC)
+        int travelNumber = 10;
+        int hostNumber = 1;
+        TravelDetailResponse travelDetailResponse = createDetailResponse(travelNumber, hostNumber);
+        TravelDetailLoginMemberRelatedDto memberRelatedDto = TravelDetailLoginMemberRelatedDto.builder()
+                .isHostUser(false)
+                .enrollmentNumber(5L)
+                .isBookmarked(true)
                 .build();
 
+        given(travelService.getDetailsByNumber(anyInt()))
+                .willReturn(travelDetailResponse);
+        given(travelService.getTravelDetailMemberRelatedInfo(anyInt(), anyInt(), anyInt(), anyString()))
+                .willReturn(memberRelatedDto);
+
         // when
-        ResultActions resultActions = mockMvc.perform(get(url, savedTravel.getNumber(), travelLocation));
+        ResultActions resultActions = mockMvc.perform(get("/api/travel/detail/{travelNumber}", travelNumber));
 
         // then
         resultActions
-                .andExpect(status().is5xxServerError());
-    }*/
-
-    @DisplayName("getDetailsByNumber: Deleted 상태의 콘텐츠 단건 조회를 하면 예외가 발생")
-    @Test
-    //@DirtiesContext
-    public void getDetailsByNumberDeletedException() throws Exception {
-        // given
-        String url = "/api/travel/detail/{travelNumber}";
-        Travel savedTravel = createTravel(user.getUserNumber(), TravelStatus.DELETED);
-        Location travelLocation = Location.builder()
-                .locationName("Seoul" + UUID.randomUUID().toString())
-                .locationType(LocationType.DOMESTIC)
-                .build();
-
-        // when
-        ResultActions resultActions = mockMvc.perform(get(url, savedTravel.getNumber(), travelLocation));
-
-        // then
-        resultActions
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.travelNumber").value(10))
+                .andExpect(jsonPath("$.userNumber").value(1))
+                .andExpect(jsonPath("$.userName").value("주최자명"))
+                .andExpect(jsonPath("$.userAgeGroup").value("20대"))
+                .andExpect(jsonPath("$.profileUrl").value("https://user-profile-url"))
+                .andExpect(jsonPath("$.createdAt").value("2024-12-06 12:00"))
+                .andExpect(jsonPath("$.location").value("서울"))
+                .andExpect(jsonPath("$.title").value("여행 제목"))
+                .andExpect(jsonPath("$.details").value("여행 상세 내용"))
+                .andExpect(jsonPath("$.viewCount").value(10))
+                .andExpect(jsonPath("$.enrollCount").value(2))
+                .andExpect(jsonPath("$.bookmarkCount").value(5))
+                .andExpect(jsonPath("$.nowPerson").value(1))
+                .andExpect(jsonPath("$.maxPerson").value(4))
+                .andExpect(jsonPath("$.genderType").value("모두"))
+                .andExpect(jsonPath("$.dueDate").value("2024-12-30"))
+                .andExpect(jsonPath("$.tags[0]").value("자연"))
+                .andExpect(jsonPath("$.tags[1]").value("쇼핑"))
+                .andExpect(jsonPath("$.postStatus").value("진행중"))
+                .andExpect(jsonPath("$.loginMemberRelatedInfo.hostUser").value(false))
+                .andExpect(jsonPath("$.loginMemberRelatedInfo.enrollmentNumber").value(5L))
+                .andExpect(jsonPath("$.loginMemberRelatedInfo.bookmarked").value(true));
+        then(travelService).should().getDetailsByNumber(travelNumber);
+        then(travelService).should().getTravelDetailMemberRelatedInfo(2, 10, 1, "진행중");
     }
 
-    private Travel createTravel(int userNumber, TravelStatus status) {
-        Location travelLocation = Location.builder()
-                .locationName("Seoul")
-                .locationType(LocationType.DOMESTIC)
-                .build();
-        Location savedLocation = locationRepository.save(travelLocation);
-        return travelRepository.save(Travel.builder()
-                .title("Travel Controller")
-                .location(travelLocation)
+    private TravelDetailResponse createDetailResponse(int travelNumber, int userNumber) {
+        return TravelDetailResponse.builder()
+                .travelNumber(travelNumber)
                 .userNumber(userNumber)
-                .genderType(GenderType.NONE)
-                .periodType(PeriodType.NONE)
-                .status(status)
-                .build()
-        );
+                .userName("주최자명")
+                .userAgeGroup(AgeGroup.TWENTY.getValue())
+                .profileUrl("https://user-profile-url")
+                .createdAt(LocalDateTime.of(2024, 12, 06, 12, 0))
+                .location("서울")
+                .title("여행 제목")
+                .details("여행 상세 내용")
+                .viewCount(10)
+                .enrollCount(2)
+                .bookmarkCount(5)
+                .nowPerson(1)
+                .maxPerson(4)
+                .genderType(GenderType.MIXED.getDescription())
+                .dueDate(LocalDate.of(2024, 12, 30))
+                .periodType(PeriodType.ONE_WEEK.getDescription())
+                .tags(List.of("자연", "쇼핑"))
+                .postStatus(TravelStatus.IN_PROGRESS.toString())
+                .build();
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
@@ -2,7 +2,6 @@ package swyp.swyp6_team7.travel.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +12,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import swyp.swyp6_team7.mock.WithMockCustomUser;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForNonMemberDto;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.service.TravelHomeService;
 
@@ -27,7 +28,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -82,7 +82,7 @@ class TravelHomeControllerTest {
 
     @DisplayName("getRecentlyCreatedTravels: 비로그인 사용자도 최근 생성된 여행 순서로 여행 목록을 조회할 수 있다.")
     @Test
-    void getRecentlyCreatedTravelsWhenNonMember() throws Exception {
+    void getRecentlyCreatedTravelsWhenNotLogin() throws Exception {
         // given
         LocalDateTime createdAt = LocalDateTime.of(2024, 12, 5, 12, 0);
         TravelRecentDto travel1 = createRecentDto(10, 1, createdAt, false);
@@ -118,6 +118,98 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.content[1].bookmarked").value(false));
     }
 
+    @DisplayName("getRecommendTravels: 로그인 사용자는 추천 여행 목록을 조회할 수 있다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    void getRecommendTravelsWhenLogin() throws Exception {
+        // given
+        TravelRecommendForMemberDto travel1 = createdRecommendDto(10, 1, List.of(), 0, false);
+        TravelRecommendForMemberDto travel2 = createdRecommendDto(11, 2, List.of("자연", "쇼핑"), 2, true);
+        List<TravelRecommendForMemberDto> travels = Arrays.asList(travel2, travel1);
+
+        Page<TravelRecommendForMemberDto> result = new PageImpl<>(travels, PageRequest.of(0, 5), travels.size());
+        given(travelHomeService.getRecommendTravelsByMember(any(PageRequest.class), anyInt(), any(LocalDate.class)))
+                .willReturn(result);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/travels/recommend"));
+
+        // then
+        then(travelHomeService).should(times(1))
+                .getRecommendTravelsByMember(any(PageRequest.class), anyInt(), any(LocalDate.class));
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].travelNumber").value(11))
+                .andExpect(jsonPath("$.content[0].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[0].location").value("서울"))
+                .andExpect(jsonPath("$.content[0].userNumber").value(2))
+                .andExpect(jsonPath("$.content[0].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[0].tags[0]").value("자연"))
+                .andExpect(jsonPath("$.content[0].tags[1]").value("쇼핑"))
+                .andExpect(jsonPath("$.content[0].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[0].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[0].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[0].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[0].bookmarked").value(true))
+                .andExpect(jsonPath("$.content[1].travelNumber").value(10))
+                .andExpect(jsonPath("$.content[1].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[1].location").value("서울"))
+                .andExpect(jsonPath("$.content[1].userNumber").value(1))
+                .andExpect(jsonPath("$.content[1].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[1].tags").isEmpty())
+                .andExpect(jsonPath("$.content[1].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[1].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[1].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[1].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[1].bookmarked").value(false));
+    }
+
+    @DisplayName("getRecommendTravels: 비로그인 사용자는 추천 여행 목록을 조회할 수 있다.")
+    @Test
+    void getRecommendTravelsWhenNotLogin() throws Exception {
+        // given
+        TravelRecommendForNonMemberDto travel1 = createRecommendForNonMemberDto(10,1);
+        TravelRecommendForNonMemberDto travel2 = createRecommendForNonMemberDto(11,2);
+        List<TravelRecommendForNonMemberDto> travels = Arrays.asList(travel2, travel1);
+
+        Page<TravelRecommendForNonMemberDto> result = new PageImpl<>(travels, PageRequest.of(0, 5), travels.size());
+        given(travelHomeService.getRecommendTravelsByNonMember(any(PageRequest.class), any(LocalDate.class)))
+                .willReturn(result);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/travels/recommend"));
+
+        // then
+        then(travelHomeService).should(times(1))
+                .getRecommendTravelsByNonMember(any(PageRequest.class), any(LocalDate.class));
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].travelNumber").value(11))
+                .andExpect(jsonPath("$.content[0].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[0].location").value("서울"))
+                .andExpect(jsonPath("$.content[0].userNumber").value(2))
+                .andExpect(jsonPath("$.content[0].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[0].tags").isEmpty())
+                .andExpect(jsonPath("$.content[0].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[0].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[0].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[0].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[0].bookmarked").value(false))
+                .andExpect(jsonPath("$.content[1].travelNumber").value(10))
+                .andExpect(jsonPath("$.content[1].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[1].location").value("서울"))
+                .andExpect(jsonPath("$.content[1].userNumber").value(1))
+                .andExpect(jsonPath("$.content[1].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[1].tags").isEmpty())
+                .andExpect(jsonPath("$.content[1].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[1].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[1].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[1].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[1].bookmarked").value(false));
+    }
+
     private TravelRecentDto createRecentDto(int travelNumber, int userNumber, LocalDateTime createdAt, boolean bookmarked) {
         return TravelRecentDto.builder()
                 .travelNumber(travelNumber)
@@ -131,6 +223,38 @@ class TravelHomeControllerTest {
                 .createdAt(createdAt)
                 .registerDue(LocalDate.of(2024, 12, 30))
                 .isBookmarked(bookmarked)
+                .build();
+    }
+
+    private TravelRecommendForMemberDto createdRecommendDto(int travelNumber, int userNumber, List<String> tags, int preferredNumber, boolean bookmarked) {
+        return TravelRecommendForMemberDto.builder()
+                .travelNumber(travelNumber)
+                .title("여행 제목")
+                .location("서울")
+                .userName("주최자명")
+                .userNumber(userNumber)
+                .tags(tags)
+                .nowPerson(1)
+                .maxPerson(3)
+                .createdAt(LocalDateTime.of(2024, 12, 5, 12, 0))
+                .registerDue(LocalDate.of(2024, 12, 30))
+                .preferredNumber(preferredNumber)
+                .isBookmarked(bookmarked)
+                .build();
+    }
+
+    private TravelRecommendForNonMemberDto createRecommendForNonMemberDto(int travelNumber, int userNumber) {
+        return TravelRecommendForNonMemberDto.builder()
+                .travelNumber(travelNumber)
+                .title("여행 제목")
+                .location("서울")
+                .userName("주최자명")
+                .userNumber(userNumber)
+                .tags(List.of())
+                .nowPerson(1)
+                .maxPerson(3)
+                .createdAt(LocalDateTime.of(2024, 12, 5, 12, 0))
+                .registerDue(LocalDate.of(2024, 12, 30))
                 .build();
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
@@ -1,0 +1,136 @@
+package swyp.swyp6_team7.travel.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import swyp.swyp6_team7.mock.WithMockCustomUser;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
+import swyp.swyp6_team7.travel.service.TravelHomeService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TravelHomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TravelHomeService travelHomeService;
+
+
+    @DisplayName("getRecentlyCreatedTravels: 최근 생성된 여행 순서로 여행 목록을 조회할 수 있다.")
+    @WithMockCustomUser(userNumber = 2)
+    @Test
+    void getRecentlyCreatedTravels() throws Exception {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2024, 12, 5, 12, 0);
+        TravelRecentDto travel1 = createRecentDto(10, 1, createdAt, true);
+        TravelRecentDto travel2 = createRecentDto(11, 2, createdAt.plusDays(1), false);
+        List<TravelRecentDto> travels = Arrays.asList(travel2, travel1);
+        Page<TravelRecentDto> result = new PageImpl<>(travels, PageRequest.of(0, 5), travels.size());
+
+        given(travelHomeService.getTravelsSortedByCreatedAt(any(PageRequest.class), any(Integer.class)))
+                .willReturn(result);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/travels/recent"));
+
+        // then
+        then(travelHomeService).should(times(1)).getTravelsSortedByCreatedAt(PageRequest.of(0, 5), 2);
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].travelNumber").value(11))
+                .andExpect(jsonPath("$.content[0].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[0].location").value("서울"))
+                .andExpect(jsonPath("$.content[0].userNumber").value(2))
+                .andExpect(jsonPath("$.content[0].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[0].tags").isEmpty())
+                .andExpect(jsonPath("$.content[0].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[0].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[0].createdAt").value("2024-12-06 12:00"))
+                .andExpect(jsonPath("$.content[0].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[0].bookmarked").value(false))
+                .andExpect(jsonPath("$.content[1].travelNumber").value(10))
+                .andExpect(jsonPath("$.content[1].userNumber").value(1))
+                .andExpect(jsonPath("$.content[1].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[1].bookmarked").value(true));
+    }
+
+    @DisplayName("getRecentlyCreatedTravels: 비로그인 사용자도 최근 생성된 여행 순서로 여행 목록을 조회할 수 있다.")
+    @Test
+    void getRecentlyCreatedTravelsWhenNonMember() throws Exception {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2024, 12, 5, 12, 0);
+        TravelRecentDto travel1 = createRecentDto(10, 1, createdAt, false);
+        TravelRecentDto travel2 = createRecentDto(11, 2, createdAt.plusDays(1), false);
+        List<TravelRecentDto> travels = Arrays.asList(travel2, travel1);
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<TravelRecentDto> result = new PageImpl<>(travels, pageRequest, travels.size());
+
+        given(travelHomeService.getTravelsSortedByCreatedAt(pageRequest, null))
+                .willReturn(result);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/travels/recent"));
+
+        // then
+        then(travelHomeService).should(times(1)).getTravelsSortedByCreatedAt(PageRequest.of(0, 5), null);
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].travelNumber").value(11))
+                .andExpect(jsonPath("$.content[0].title").value("여행 제목"))
+                .andExpect(jsonPath("$.content[0].location").value("서울"))
+                .andExpect(jsonPath("$.content[0].userNumber").value(2))
+                .andExpect(jsonPath("$.content[0].userName").value("주최자명"))
+                .andExpect(jsonPath("$.content[0].tags").isEmpty())
+                .andExpect(jsonPath("$.content[0].nowPerson").value(1))
+                .andExpect(jsonPath("$.content[0].maxPerson").value(3))
+                .andExpect(jsonPath("$.content[0].createdAt").value("2024-12-06 12:00"))
+                .andExpect(jsonPath("$.content[0].registerDue").value("2024-12-30"))
+                .andExpect(jsonPath("$.content[0].bookmarked").value(false))
+                .andExpect(jsonPath("$.content[1].travelNumber").value(10))
+                .andExpect(jsonPath("$.content[1].userNumber").value(1))
+                .andExpect(jsonPath("$.content[1].createdAt").value("2024-12-05 12:00"))
+                .andExpect(jsonPath("$.content[1].bookmarked").value(false));
+    }
+
+    private TravelRecentDto createRecentDto(int travelNumber, int userNumber, LocalDateTime createdAt, boolean bookmarked) {
+        return TravelRecentDto.builder()
+                .travelNumber(travelNumber)
+                .title("여행 제목")
+                .location("서울")
+                .userName("주최자명")
+                .userNumber(userNumber)
+                .tags(List.of())
+                .nowPerson(1)
+                .maxPerson(3)
+                .createdAt(createdAt)
+                .registerDue(LocalDate.of(2024, 12, 30))
+                .isBookmarked(bookmarked)
+                .build();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -82,12 +82,12 @@ class TravelCustomRepositoryImplTest {
         travelRepository.save(travel1);
 
         // when
-        TravelDetailDto details = travelRepository.getDetailsByNumber(travel1.getNumber(), 1);
+        TravelDetailDto details = travelRepository.getDetailsByNumber(travel1.getNumber());
 
         // then
         assertThat(details)
-                .extracting("travel", "hostNumber", "hostName", "hostAgeGroup", "companionCount", "tags", "bookmarked")
-                .contains(travel1, host.getUserNumber(), "주최자 이름", "10대", 0, List.of("쇼핑", "자연"), false);
+                .extracting("travel", "hostNumber", "hostName", "hostAgeGroup", "companionCount", "tags")
+                .contains(travel1, host.getUserNumber(), "주최자 이름", "10대", 0, List.of("쇼핑", "자연"));
     }
 
     @DisplayName("findAll: 여행을 최신순으로 가져올 수 있다.")

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -4,9 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import swyp.swyp6_team7.bookmark.entity.Bookmark;
@@ -60,9 +58,6 @@ class TravelCustomRepositoryImplTest {
     @Autowired
     private BookmarkRepository bookmarkRepository;
 
-    @MockBean
-    private DateTimeProvider dateTimeProvider;
-
 
     @DisplayName("getDetailsByNumber: 여행 번호가 주어지면 여행의 디테일 정보를 가져올 수 있다.")
     @Test
@@ -111,14 +106,14 @@ class TravelCustomRepositoryImplTest {
 
         // when
         Page<TravelRecentDto> results = travelRepository
-                .findAllSortedByCreatedAt(PageRequest.of(0, 5), 1);
+                .findAllSortedByCreatedAt(PageRequest.of(0, 5));
 
         // then
         assertThat(results.getContent()).hasSize(2)
-                .extracting("travelNumber", "title", "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue", "bookmarked")
+                .extracting("travelNumber", "title", "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue")
                 .containsExactly(
-                        tuple(travel2.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 0, dueDate, false),
-                        tuple(travel1.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 2, dueDate, false)
+                        tuple(travel2.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 0, dueDate),
+                        tuple(travel1.getNumber(), "여행", "Seoul", 1, "주최자 이름", List.of(), 0, 2, dueDate)
                 );
     }
 

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -225,10 +225,9 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
-        assertThat(results.getTotalElements()).isEqualTo(1);
         assertThat(results.getContent()).hasSize(1)
                 .extracting("title")
                 .allMatch(title -> ((String) title).contains("키워드"));
@@ -255,10 +254,9 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
-        assertThat(results.getTotalElements()).isEqualTo(1);
         assertThat(results.getContent()).hasSize(1)
                 .extracting("location")
                 .allMatch(locationName -> ((String) locationName).contains("Seoul"));
@@ -284,7 +282,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getContent()).hasSize(2);
@@ -312,7 +310,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getContent()).hasSize(2)
@@ -344,7 +342,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
 
         // then
         assertThat(result.getContent()).hasSize(1)
@@ -376,7 +374,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
 
         // then
         assertThat(result.getContent()).hasSize(2)
@@ -407,7 +405,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
 
         // then
         assertThat(result.getContent()).hasSize(2)
@@ -442,7 +440,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> result = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> result = travelRepository.search(condition);
 
         // then
         assertThat(result.getContent()).hasSize(2)
@@ -476,7 +474,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> domesticResults = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> domesticResults = travelRepository.search(condition);
 
         // then
         assertThat(domesticResults.getContent()).hasSize(2)
@@ -509,7 +507,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> domesticResults = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> domesticResults = travelRepository.search(condition);
 
         // then
         assertThat(domesticResults.getContent()).hasSize(2)
@@ -539,7 +537,36 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
+
+        // then
+        assertThat(results.getContent()).hasSize(3)
+                .extracting("travelNumber")
+                .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
+    }
+
+    @DisplayName("search: 검색할 때 정렬 키워드가 주어지지 않았을 때, dueDate가 동일하면 최근 생성된 순서로 정렬된다.")
+    @Test
+    public void searchWithoutSortingType2() {
+        // given
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
+        Travel travel2 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
+        Travel travel3 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getContent()).hasSize(3)
@@ -576,7 +603,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getContent()).hasSize(3)
@@ -613,7 +640,7 @@ class TravelCustomRepositoryImplTest {
                 .build();
 
         // when
-        Page<TravelSearchDto> results = travelRepository.search(condition, 1);
+        Page<TravelSearchDto> results = travelRepository.search(condition);
 
         // then
         assertThat(results.getContent()).hasSize(3)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import swyp.swyp6_team7.bookmark.service.BookmarkService;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.location.repository.LocationRepository;
@@ -20,16 +21,20 @@ import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static swyp.swyp6_team7.travel.domain.TravelStatus.IN_PROGRESS;
 
 
@@ -54,6 +59,9 @@ class TravelHomeServiceTest {
     @MockBean
     private UserTagPreferenceRepository userTagPreferenceRepository;
 
+    @MockBean
+    private BookmarkService bookmarkService;
+
     @AfterEach
     void tearDown() {
         travelTagRepository.deleteAllInBatch();
@@ -62,6 +70,64 @@ class TravelHomeServiceTest {
         locationRepository.deleteAllInBatch();
     }
 
+    @DisplayName("최근 생성된 순서로 여행 목록을 가져오고 로그인 상태인 경우 사용자의 북마크 여부를 추가로 설정한다.")
+    @Test
+    void getTravelsSortedByCreatedAt() {
+        // given
+        Integer loginUserNumber = 1;
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+        Travel travel2 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+
+        Map<Integer, Boolean> bookmarkedMap = new HashMap<>();
+        bookmarkedMap.put(travel1.getNumber(), true);
+        bookmarkedMap.put(travel2.getNumber(), false);
+        given(bookmarkService.getBookmarkExistenceByTravelNumbers(anyInt(), anyList()))
+                .willReturn(bookmarkedMap);
+
+        // when
+        Page<TravelRecentDto> result = travelHomeService.getTravelsSortedByCreatedAt(PageRequest.of(0, 5), loginUserNumber);
+
+        // then
+        then(bookmarkService).should().getBookmarkExistenceByTravelNumbers(loginUserNumber, List.of(travel2.getNumber(), travel1.getNumber()));
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber", "bookmarked")
+                .containsExactly(
+                        tuple(travel2.getNumber(), false),
+                        tuple(travel1.getNumber(), true)
+                );
+    }
+
+    @DisplayName("최근 생성된 순서로 여행 목록을 가져오고 비로그인 상태인 경우 사용자의 북마크 여부는 전부 false이다.")
+    @Test
+    void getTravelsSortedByCreatedAtWhenNotLogin() {
+        // given
+        Integer loginUserNumber = null;
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+        Travel travel2 = travelRepository.save(createTravel(
+                1, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+
+        // when
+        Page<TravelRecentDto> result = travelHomeService.getTravelsSortedByCreatedAt(PageRequest.of(0, 5), loginUserNumber);
+
+        // then
+        assertThat(result.getContent()).hasSize(2)
+                .extracting("travelNumber", "bookmarked")
+                .containsExactly(
+                        tuple(travel2.getNumber(), false),
+                        tuple(travel1.getNumber(), false)
+                );
+    }
 
     @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 큰 순서대로 여행 목록을 가져온다.")
     @Test

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
@@ -20,7 +20,7 @@ import swyp.swyp6_team7.travel.domain.GenderType;
 import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
 import swyp.swyp6_team7.travel.dto.response.TravelRecentDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
@@ -131,7 +131,7 @@ class TravelHomeServiceTest {
 
     @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 큰 순서대로 여행 목록을 가져온다.")
     @Test
-    void getRecommendTravelsByUser() {
+    void getRecommendTravelsByMember() {
         // given
         Tag tag1 = Tag.of("쇼핑");
         Tag tag2 = Tag.of("자연");
@@ -161,7 +161,7 @@ class TravelHomeServiceTest {
                 .willReturn(Arrays.asList("쇼핑", "자연", "먹방"));
 
         // when
-        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1, requestDate);
+        Page<TravelRecommendForMemberDto> result = travelHomeService.getRecommendTravelsByMember(PageRequest.of(0, 5), 1, requestDate);
 
         // then
         assertThat(result.getContent()).hasSize(4)
@@ -176,7 +176,7 @@ class TravelHomeServiceTest {
 
     @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 동일한 경우 registerDue가 빠른 순서대로 여행을 가져온다.")
     @Test
-    void getRecommendTravelsByUserWhenSamePreferredNumber() {
+    void getRecommendTravelsByMemberWhenSamePreferredNumber() {
         Tag tag1 = Tag.of("쇼핑");
         Tag tag2 = Tag.of("자연");
         tagRepository.saveAll(List.of(tag1, tag2));
@@ -197,7 +197,7 @@ class TravelHomeServiceTest {
                 .willReturn(Arrays.asList("쇼핑", "자연"));
 
         // when
-        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1, requestDate);
+        Page<TravelRecommendForMemberDto> result = travelHomeService.getRecommendTravelsByMember(PageRequest.of(0, 5), 1, requestDate);
 
         // then
         assertThat(result.getContent()).hasSize(2)
@@ -210,7 +210,7 @@ class TravelHomeServiceTest {
 
     @DisplayName("preferredNumber, registerDue가 동일한 경우 title을 기준으로 가나다 순서대로 가져온다.")
     @Test
-    void getRecommendTravelsByUserWhenSamePreferredNumberSameRegisterDue() {
+    void getRecommendTravelsByMemberWhenSamePreferredNumberSameRegisterDue() {
         Tag tag1 = Tag.of("쇼핑");
         Tag tag2 = Tag.of("자연");
         tagRepository.saveAll(List.of(tag1, tag2));
@@ -231,7 +231,7 @@ class TravelHomeServiceTest {
                 .willReturn(Arrays.asList("쇼핑", "자연"));
 
         // when
-        Page<TravelRecommendDto> result = travelHomeService.getRecommendTravelsByUser(PageRequest.of(0, 5), 1, requestDate);
+        Page<TravelRecommendForMemberDto> result = travelHomeService.getRecommendTravelsByMember(PageRequest.of(0, 5), 1, requestDate);
 
         // then
         assertThat(result.getContent()).hasSize(2)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
@@ -1,0 +1,192 @@
+package swyp.swyp6_team7.travel.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import swyp.swyp6_team7.bookmark.service.BookmarkService;
+import swyp.swyp6_team7.location.domain.Location;
+import swyp.swyp6_team7.location.domain.LocationType;
+import swyp.swyp6_team7.location.repository.LocationRepository;
+import swyp.swyp6_team7.member.entity.AgeGroup;
+import swyp.swyp6_team7.member.entity.Gender;
+import swyp.swyp6_team7.member.entity.UserStatus;
+import swyp.swyp6_team7.member.entity.Users;
+import swyp.swyp6_team7.member.repository.UserRepository;
+import swyp.swyp6_team7.tag.domain.Tag;
+import swyp.swyp6_team7.tag.repository.TagRepository;
+import swyp.swyp6_team7.tag.repository.TravelTagRepository;
+import swyp.swyp6_team7.travel.domain.GenderType;
+import swyp.swyp6_team7.travel.domain.PeriodType;
+import swyp.swyp6_team7.travel.domain.Travel;
+import swyp.swyp6_team7.travel.domain.TravelStatus;
+import swyp.swyp6_team7.travel.dto.TravelSearchCondition;
+import swyp.swyp6_team7.travel.dto.response.TravelSearchDto;
+import swyp.swyp6_team7.travel.repository.TravelRepository;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static swyp.swyp6_team7.travel.domain.TravelStatus.IN_PROGRESS;
+
+@SpringBootTest
+class TravelSearchServiceTest {
+
+    @Autowired
+    private TravelSearchService travelSearchService;
+
+    @Autowired
+    private TravelRepository travelRepository;
+
+    @Autowired
+    private TravelTagRepository travelTagRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private BookmarkService bookmarkService;
+
+
+    @AfterEach
+    void tearDown() {
+        travelTagRepository.deleteAllInBatch();
+        travelRepository.deleteAllInBatch();
+        tagRepository.deleteAllInBatch();
+        locationRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("search: 비로그인 사용자도 주어진 검색 조건에 대해 여행 목록을 조회할 수 있다.")
+    @Test
+    void searchWhenNotLogin() {
+        // given
+        Integer hostUserNumber = userRepository.save(createHostUser()).getUserNumber();
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = travelRepository.save(createTravel(
+                hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+        Travel travel2 = travelRepository.save(createTravel(
+                hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+
+        // when
+        Page<TravelSearchDto> result = travelSearchService.search(condition, null);
+
+        // then
+        assertThat(result).hasSize(2)
+                .extracting("travelNumber", "title", "location", "userNumber", "userName",
+                        "tags", "nowPerson", "maxPerson", "registerDue", "postStatus", "bookmarked")
+                .containsExactly(
+                        tuple(travel1.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, dueDate, IN_PROGRESS.getName(), false),
+                        tuple(travel2.getNumber(),"여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, dueDate.plusDays(1), IN_PROGRESS.getName(), false)
+                );
+    }
+
+    @DisplayName("search: 로그인 사용자는 주어진 검색 조건에 대해 여행 목록을 조회하고 북마크 여부까지 알 수 있다.")
+    @Test
+    void search() {
+        // given
+        Integer hostUserNumber = userRepository.save(createHostUser()).getUserNumber();
+        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
+        LocalDate dueDate = LocalDate.of(2024, 11, 7);
+        Travel travel1 = travelRepository.save(createTravel(
+                hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+        Travel travel2 = travelRepository.save(createTravel(
+                hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
+                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+
+        Map<Integer, Boolean> bookmarkedMap = new HashMap<>();
+        bookmarkedMap.put(travel1.getNumber(), true);
+        bookmarkedMap.put(travel2.getNumber(), false);
+        given(bookmarkService.getBookmarkExistenceByTravelNumbers(anyInt(), anyList()))
+                .willReturn(bookmarkedMap);
+
+        TravelSearchCondition condition = TravelSearchCondition.builder()
+                .pageRequest(PageRequest.of(0, 5))
+                .build();
+        Integer loginUserNumber = 10;
+
+        // when
+        Page<TravelSearchDto> result = travelSearchService.search(condition, loginUserNumber);
+
+        // then
+        then(bookmarkService).should(times(1))
+                .getBookmarkExistenceByTravelNumbers(10, List.of(travel1.getNumber(), travel2.getNumber()));
+        assertThat(result).hasSize(2)
+                .extracting("travelNumber", "title", "location", "userNumber", "userName",
+                        "tags", "nowPerson", "maxPerson", "registerDue", "postStatus", "bookmarked")
+                .containsExactly(
+                        tuple(travel1.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, dueDate, IN_PROGRESS.getName(), true),
+                        tuple(travel2.getNumber(),"여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, dueDate.plusDays(1), IN_PROGRESS.getName(), false)
+                );
+    }
+
+    private Users createHostUser() {
+        return Users.builder()
+                .userPw("1234")
+                .userEmail("test@mail.com")
+                .userName("주최자명")
+                .userGender(Gender.M)
+                .userAgeGroup(AgeGroup.TEEN)
+                .userStatus(UserStatus.ABLE)
+                .build();
+    }
+
+    private Location createLocation(String locationName, LocationType locationType) {
+        return Location.builder()
+                .locationName(locationName)
+                .locationType(locationType)
+                .build();
+    }
+
+    private Travel createTravel(
+            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
+            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+    ) {
+        return Travel.builder()
+                .userNumber(hostNumber)
+                .location(location)
+                .locationName(location.getLocationName())
+                .title(title)
+                .details("여행 내용")
+                .viewCount(viewCount)
+                .maxPerson(maxPerson)
+                .genderType(genderType)
+                .dueDate(dueDate)
+                .periodType(periodType)
+                .status(status)
+                .tags(tags)
+                .build();
+    }
+}

--- a/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
@@ -2,7 +2,7 @@ package swyp.swyp6_team7.travel.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import swyp.swyp6_team7.travel.dto.TravelRecommendDto;
+import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -17,13 +17,13 @@ class TravelRecommendComparatorTest {
     @Test
     public void compareTo() {
         // given
-        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto1 = TravelRecommendForMemberDto.builder()
                 .preferredNumber(1)
                 .build();
-        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto2 = TravelRecommendForMemberDto.builder()
                 .preferredNumber(5)
                 .build();
-        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+        List<TravelRecommendForMemberDto> result = new ArrayList<>(List.of(dto1, dto2));
 
         // when
         Collections.sort(result, new TravelRecommendComparator());
@@ -37,15 +37,15 @@ class TravelRecommendComparatorTest {
     @Test
     public void compareToWhenPreferredNumberSame() {
         // given
-        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto1 = TravelRecommendForMemberDto.builder()
                 .preferredNumber(5)
                 .registerDue(LocalDate.now().plusDays(5))
                 .build();
-        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto2 = TravelRecommendForMemberDto.builder()
                 .preferredNumber(5)
                 .registerDue(LocalDate.now().plusDays(1))
                 .build();
-        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+        List<TravelRecommendForMemberDto> result = new ArrayList<>(List.of(dto1, dto2));
 
         // when
         Collections.sort(result, new TravelRecommendComparator());
@@ -59,17 +59,17 @@ class TravelRecommendComparatorTest {
     @Test
     public void compareToWhenDueDateSame() {
         // given
-        TravelRecommendDto dto1 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto1 = TravelRecommendForMemberDto.builder()
                 .title("나")
                 .preferredNumber(5)
                 .registerDue(LocalDate.now().plusDays(5))
                 .build();
-        TravelRecommendDto dto2 = TravelRecommendDto.builder()
+        TravelRecommendForMemberDto dto2 = TravelRecommendForMemberDto.builder()
                 .title("가다")
                 .preferredNumber(5)
                 .registerDue(LocalDate.now().plusDays(5))
                 .build();
-        List<TravelRecommendDto> result = new ArrayList<>(List.of(dto1, dto2));
+        List<TravelRecommendForMemberDto> result = new ArrayList<>(List.of(dto1, dto2));
 
         // when
         Collections.sort(result, new TravelRecommendComparator());


### PR DESCRIPTION
## 🔗 Issue Number

> 연관된 이슈 번호를 기입해주세요.   
> ex) #이슈번호, #이슈번호

## PR 유형
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [X] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
여행 관련 API 중 일부에 대해 비로그인 사용자의 요청에도 동작하도록 기능을 수정함

MemberAuthorizeUtil 수정
* Authentication을 확인해 유효한 경우에만 userNumber를 가져오도록 조건문을 추가함
```
    public static Integer getLoginUserNumber() {
        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

        // 로그인 한 경우
        if (authentication != null && authentication.isAuthenticated()) {
            if (authentication.getPrincipal() instanceof CustomUserDetails) {
                CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
                Integer userNumber = userDetails.getUserNumber();
                return userNumber;
            }
        }

        // 로그인 하지 않은 경우
        return null;
    }
```


비로그인 로직 추가 API 목록
* 여행 단건 상세 조회: `/api/travel/detail/{travelNumber}`
* 여행 검색: `/api/travels/search`
* 메인 페이지 - 참가 가능한 여행: `/api/travels/recent`
* 메인 페이지 - 추천 여행: `/api/travels/recommend`
   * 로그인 사용자: 기존과 동일하게 사용자 선호 태그 기반으로 결과를 조회
   * 비로그인 사용자: 북마크(좋아요) 개수가 많은 순서 + 제목 사전순으로 결과를 조회

## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
