### PR TITLE
feat: 커뮤니티 "전체" 카테고리 요청 처리 로직 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/category/intializer/CategoryInitializer.java
+++ b/src/main/java/swyp/swyp6_team7/category/intializer/CategoryInitializer.java
@@ -20,6 +20,7 @@ public class CategoryInitializer {
         // 카테고리가 존재하지 않을 때만 데이터 삽입
         if (categoryRepository.count() == 0) {
             categoryRepository.saveAll(List.of(
+                    new Category("전체"),
                     new Category("잡담"),
                     new Category("여행팁"),
                     new Category("후기")

--- a/src/main/java/swyp/swyp6_team7/community/controller/CommunityController.java
+++ b/src/main/java/swyp/swyp6_team7/community/controller/CommunityController.java
@@ -72,14 +72,13 @@ public class CommunityController {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         Integer categoryNumber = null;
-        // categoryName이 null이 아닐 경우에만 카테고리 번호를 조회
-        if (categoryName != null) {
+        if (categoryName != null && !categoryName.equals("전체")) {
             categoryNumber = categoryRepository.findByCategoryName(categoryName)
                     .map(Category::getCategoryNumber)
-                    .orElse(null); // 카테고리가 없을 경우 null
+                    .orElse(null);
             if (categoryNumber == null) {
                 log.warn("유효하지 않은 카테고리 이름: {}", categoryName);
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Page.empty(pageRequest)); // 빈 페이지 반환
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Page.empty(pageRequest)); //빈 페이지 반환
             }
             log.info("커뮤니티 목록 조회 - 카테고리 이름: {}, 카테고리 번호: {}", categoryName, categoryNumber);
         }

--- a/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepository.java
+++ b/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepository.java
@@ -12,5 +12,5 @@ public interface CommunityCustomRepository {
 
     List<CommunitySearchDto> search(CommunitySearchCondition searchCondition);
     List<CommunitySearchDto> getMyList(CommunitySearchSortingType sortingType, int userNumber);
-
+    List<CommunitySearchDto> searchWithoutCategory(CommunitySearchCondition searchCondition);
 }

--- a/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepositoryImpl.java
@@ -180,36 +180,6 @@ public class CommunityCustomRepositoryImpl implements CommunityCustomRepository 
                 .toList();
     }
 
-    public List<CommunitySearchDto> searchWithoutCategory(CommunitySearchCondition searchCondition) {
-        // 게시글과 관련된 정보 + 좋아요 수 집계 쿼리
-        List<Tuple> content = queryFactory
-                .select(
-                        community,
-                        categories.categoryName,
-                        like.count().coalesce(0L) // 좋아요 수 집계
-                )
-                .from(community)
-                .leftJoin(categories).on(community.categoryNumber.eq(categories.categoryNumber))
-                .leftJoin(like).on(community.postNumber.eq(like.relatedNumber)
-                        .and(like.relatedType.eq("community")))
-                .where(
-                        keywordContains(searchCondition.getKeyword()) // 키워드 조건만 적용
-                )
-                .groupBy(community.postNumber, categories.categoryName) // group by 적용
-                .orderBy(getOrderBy(searchCondition.getSortingType()).toArray(new OrderSpecifier[0])) // 가변인자로 변환
-                .fetch();
-
-        // 결과를 DTO로 변환
-        return content.stream()
-                .map(tuple -> new CommunitySearchDto(
-                        tuple.get(community),
-                        tuple.get(categories.categoryName),
-                        tuple.get(like.count().coalesce(0L)) // 좋아요 수 가져오기
-                ))
-                .toList();
-    }
-
-
     // 정렬 조건 설정 (좋아요 순 정렬 포함)
     private List<OrderSpecifier<?>> getOrderBy(CommunitySearchSortingType sortingType) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();

--- a/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/community/repository/CommunityCustomRepositoryImpl.java
@@ -180,6 +180,36 @@ public class CommunityCustomRepositoryImpl implements CommunityCustomRepository 
                 .toList();
     }
 
+    public List<CommunitySearchDto> searchWithoutCategory(CommunitySearchCondition searchCondition) {
+        // 게시글과 관련된 정보 + 좋아요 수 집계 쿼리
+        List<Tuple> content = queryFactory
+                .select(
+                        community,
+                        categories.categoryName,
+                        like.count().coalesce(0L) // 좋아요 수 집계
+                )
+                .from(community)
+                .leftJoin(categories).on(community.categoryNumber.eq(categories.categoryNumber))
+                .leftJoin(like).on(community.postNumber.eq(like.relatedNumber)
+                        .and(like.relatedType.eq("community")))
+                .where(
+                        keywordContains(searchCondition.getKeyword()) // 키워드 조건만 적용
+                )
+                .groupBy(community.postNumber, categories.categoryName) // group by 적용
+                .orderBy(getOrderBy(searchCondition.getSortingType()).toArray(new OrderSpecifier[0])) // 가변인자로 변환
+                .fetch();
+
+        // 결과를 DTO로 변환
+        return content.stream()
+                .map(tuple -> new CommunitySearchDto(
+                        tuple.get(community),
+                        tuple.get(categories.categoryName),
+                        tuple.get(like.count().coalesce(0L)) // 좋아요 수 가져오기
+                ))
+                .toList();
+    }
+
+
     // 정렬 조건 설정 (좋아요 순 정렬 포함)
     private List<OrderSpecifier<?>> getOrderBy(CommunitySearchSortingType sortingType) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();

--- a/src/main/java/swyp/swyp6_team7/community/service/CommunityListService.java
+++ b/src/main/java/swyp/swyp6_team7/community/service/CommunityListService.java
@@ -45,7 +45,9 @@ public class CommunityListService {
         try {
             log.info("게시물 목록 조회 요청: searchCondition={}, userNumber={}", searchCondition, userNumber);
 
-            List<CommunitySearchDto> searchedCommunities = communityCustomRepository.search(searchCondition);
+            List<CommunitySearchDto> searchedCommunities = (searchCondition.getCategoryNumber() == null)
+                    ? communityCustomRepository.searchWithoutCategory(searchCondition) // 카테고리 제외 검색
+                    : communityCustomRepository.search(searchCondition); // 일반 검색
             log.info("검색된 게시물 수: {}", searchedCommunities.size());
 
             List<CommunityListResponseDto> responseDtos = searchedCommunities.stream()

--- a/src/main/java/swyp/swyp6_team7/community/service/CommunityListService.java
+++ b/src/main/java/swyp/swyp6_team7/community/service/CommunityListService.java
@@ -45,9 +45,7 @@ public class CommunityListService {
         try {
             log.info("게시물 목록 조회 요청: searchCondition={}, userNumber={}", searchCondition, userNumber);
 
-            List<CommunitySearchDto> searchedCommunities = (searchCondition.getCategoryNumber() == null)
-                    ? communityCustomRepository.searchWithoutCategory(searchCondition) // 카테고리 제외 검색
-                    : communityCustomRepository.search(searchCondition); // 일반 검색
+            List<CommunitySearchDto> searchedCommunities = communityCustomRepository.search(searchCondition);
             log.info("검색된 게시물 수: {}", searchedCommunities.size());
 
             List<CommunityListResponseDto> responseDtos = searchedCommunities.stream()


### PR DESCRIPTION
## 🔗 Issue Number

> 

## PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용

- "전체" 카테고리 요청 처리 로직 추가
- service 계층에서 categoryNumber가 null일 경우 전체 게시물을 검색하도록 처리
- CommunityCustomRepository에 searchWithoutCategory 메서드 추가
  - 카테고리 필터 없이 모든 게시물을 검색
  - 기존 검색 로직과 동일하게 키워드, 좋아요 수 등 조건 적용
- Controller에서 categoryName="전체"를 인식하고 categoryNumber를 null로 전달하도록 수정
- 기존 로직과의 호환성을 유지하며 모든 게시물 조회 가능


## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
