### PR TITLE
test: MemberAuthorizeUtil 기반으로 사용자 번호 Mocking

### DIFF
--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelAppliedControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelAppliedControllerTest.java
@@ -2,6 +2,7 @@ package swyp.swyp6_team7.travel.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -76,26 +77,26 @@ public class TravelAppliedControllerTest {
                 .build();
         Page<TravelListResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), pageable, 1);
 
-        // when
-        //mockStatic(MemberAuthorizeUtil.class);
-        when(MemberAuthorizeUtil.getLoginUserNumber()).thenReturn(userNumber);
+        try (MockedStatic<MemberAuthorizeUtil> mockedStatic = mockStatic(MemberAuthorizeUtil.class)) {
+            mockedStatic.when(MemberAuthorizeUtil::getLoginUserNumber).thenReturn(userNumber);
 
-        when(travelAppliedService.getAppliedTripsByUser(userNumber, pageable)).thenReturn(page);
+            when(travelAppliedService.getAppliedTripsByUser(userNumber, pageable)).thenReturn(page);
 
-        // then
-        mockMvc.perform(get("/api/my-applied-travels")
-                        .header(HttpHeaders.AUTHORIZATION, token)
-                        .param("page", "0")
-                        .param("size", "5"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].travelNumber").value(25))
-                .andExpect(jsonPath("$.content[0].title").value("호주 여행 같이 갈 사람 구해요"))
-                .andExpect(jsonPath("$.content[0].userName").value("김모잉"))
-                .andExpect(jsonPath("$.content[0].tags[0]").value("즉흥"))
-                .andExpect(jsonPath("$.page.size").value(5))
-                .andExpect(jsonPath("$.page.number").value(0))
-                .andExpect(jsonPath("$.page.totalElements").value(1))
-                .andExpect(jsonPath("$.page.totalPages").value(1));
+            // then
+            mockMvc.perform(get("/api/my-applied-travels")
+                            .header(HttpHeaders.AUTHORIZATION, BEARER_TOKEN)
+                            .param("page", "0")
+                            .param("size", "5"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].travelNumber").value(25))
+                    .andExpect(jsonPath("$.content[0].title").value("호주 여행 같이 갈 사람 구해요"))
+                    .andExpect(jsonPath("$.content[0].userName").value("김모잉"))
+                    .andExpect(jsonPath("$.content[0].tags[0]").value("즉흥"))
+                    .andExpect(jsonPath("$.page.size").value(5))
+                    .andExpect(jsonPath("$.page.number").value(0))
+                    .andExpect(jsonPath("$.page.totalElements").value(1))
+                    .andExpect(jsonPath("$.page.totalPages").value(1));
+        }
 
     }
 
@@ -107,15 +108,16 @@ public class TravelAppliedControllerTest {
         int userNumber = 1;
         int travelNumber = 2;
 
-        // Mock the JwtProvider to return the userNumber from the token
-        when(jwtProvider.getUserNumber("test-token")).thenReturn(userNumber);
+        try (MockedStatic<MemberAuthorizeUtil> mockedStatic = mockStatic(MemberAuthorizeUtil.class)) {
+            mockedStatic.when(MemberAuthorizeUtil::getLoginUserNumber).thenReturn(userNumber);
 
-        // Do nothing when canceling the application
-        Mockito.doNothing().when(travelAppliedService).cancelApplication(userNumber, travelNumber);
+            // Do nothing when canceling the application
+            Mockito.doNothing().when(travelAppliedService).cancelApplication(userNumber, travelNumber);
 
-        // when & then
-        mockMvc.perform(delete("/api/my-applied-travels/{travelNumber}/cancel", travelNumber)
-                        .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
-                .andExpect(status().isNoContent());
+            // when & then
+            mockMvc.perform(delete("/api/my-applied-travels/{travelNumber}/cancel", travelNumber)
+                            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+                    .andExpect(status().isNoContent());
+        }
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelListControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelListControllerTest.java
@@ -1,9 +1,11 @@
 package swyp.swyp6_team7.travel.controller;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -53,13 +55,23 @@ public class TravelListControllerTest {
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String BEARER_TOKEN = "Bearer test-token";
 
+    private MockedStatic<MemberAuthorizeUtil> mockedStaticMemberAuthorizeUtil;
+
+    @AfterEach
+    void tearDown() {
+        // Reset static mock after each test to avoid interference
+        if (mockedStaticMemberAuthorizeUtil != null) {
+            mockedStaticMemberAuthorizeUtil.close();
+        }
+    }
+
     @DisplayName("내가 만든 여행 게시글 목록 조회 테스트")
     @WithMockUser
     @Test
     void getMyCreatedTravels_ShouldReturnListOfCreatedTravels() throws Exception {
         // given
         String token = "Bearer test-token";
-        Integer userNumber = 1;
+        //Integer userNumber = 1;
         Pageable pageable = PageRequest.of(0, 5);
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -80,10 +92,10 @@ public class TravelListControllerTest {
         Page<TravelListResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), pageable, 1);
 
         // when
-        mockStatic(MemberAuthorizeUtil.class);
-        when(MemberAuthorizeUtil.getLoginUserNumber()).thenReturn(userNumber);
+        mockedStaticMemberAuthorizeUtil = mockStatic(MemberAuthorizeUtil.class);
+        when(MemberAuthorizeUtil.getLoginUserNumber()).thenReturn(2);
 
-        when(travelListService.getTravelListByUser(userNumber, pageable)).thenReturn(page);
+        when(travelListService.getTravelListByUser(2, pageable)).thenReturn(page);
 
         // then
         mockMvc.perform(get("/api/my-travels")


### PR DESCRIPTION
## 🔗 Issue Number

> #160 #154 

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용

- 기존 jwtProvider를 사용하여 사용자 번호를 Mocking하던 부분을 MemberAuthorizeUtil.getLoginUserNumber로 변경
- mockStatic(MemberAuthorizeUtil.class) 적용하여 정적 메서드 Mocking
- 테스트 범위 내에서 MockedStatic이 유효하도록 try-with-resources 구조 적용
- @AfterEach를 사용해 테스트 독립성 보장


## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
