### PR TITLE
fix: categoryName 기본값 설정 및 예외 상세 로그 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/comment/controller/CommentController.java
+++ b/src/main/java/swyp/swyp6_team7/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package swyp.swyp6_team7.comment.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -70,6 +71,10 @@ public class CommentController {
         } catch (IllegalArgumentException e) {
             log.error("잘못된 요청 데이터 - 페이지: {}, 크기: {}, 타입: {}, 게시물 번호: {}, 오류: {}", page, size, relatedType, relatedNumber, e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("요청 데이터가 잘못되었습니다.");
+        } catch (IncorrectResultSizeDataAccessException e) {
+            log.error("댓글 목록 조회 중 예외 발생: relatedType={}, relatedNumber={}, Exception={}",
+                    relatedType, relatedNumber, e.getMessage(), e);
+            throw new RuntimeException("댓글 목록 조회에 실패했습니다.", e);
         } catch (Exception e) {
             log.error("댓글 목록 조회 중 예외 발생", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");

--- a/src/main/java/swyp/swyp6_team7/comment/service/CommentService.java
+++ b/src/main/java/swyp/swyp6_team7/comment/service/CommentService.java
@@ -112,7 +112,13 @@ public class CommentService {
 
         validateRelatedPostExists(relatedType, relatedNumber);
 
+        //List<Comment> comments = commentRepository.findByRelatedTypeAndRelatedNumber(relatedType, relatedNumber);
         List<Comment> comments = commentRepository.findByRelatedTypeAndRelatedNumber(relatedType, relatedNumber);
+        if (comments.isEmpty()) {
+            log.info("댓글이 없습니다: relatedType={}, relatedNumber={}", relatedType, relatedNumber);
+            return Collections.emptyList();
+        }
+        log.info("댓글 목록 조회: 댓글 개수={}", comments.size());
         List<Comment> sortedComments = sortComments(comments);
 
         return convertToResponseDtos(sortedComments, userNumber);
@@ -124,7 +130,13 @@ public class CommentService {
 
         validateRelatedPostExists(relatedType, relatedNumber);
 
+        //List<Comment> comments = commentRepository.findByRelatedTypeAndRelatedNumber(relatedType, relatedNumber);
         List<Comment> comments = commentRepository.findByRelatedTypeAndRelatedNumber(relatedType, relatedNumber);
+        if (comments.isEmpty()) {
+            log.info("댓글이 없습니다: relatedType={}, relatedNumber={}", relatedType, relatedNumber);
+            return Page.empty();
+        }
+        log.info("댓글 목록 조회: 댓글 개수={}", comments.size());
         List<Comment> sortedComments = sortComments(comments);
 
         List<CommentListReponseDto> responseDtos = convertToResponseDtos(sortedComments, userNumber);

--- a/src/main/java/swyp/swyp6_team7/community/controller/CommunityController.java
+++ b/src/main/java/swyp/swyp6_team7/community/controller/CommunityController.java
@@ -59,7 +59,7 @@ public class CommunityController {
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "5") int size,
             @RequestParam(name = "keyword",required = false) String keyword,
-            @RequestParam(name = "categoryName", required = false) String categoryName,
+            @RequestParam(name = "categoryName", defaultValue = "전체") String categoryName,
             @RequestParam(name = "sortingTypeName", defaultValue = "최신순") String sortingTypeName,
             Principal principal) {
 


### PR DESCRIPTION
## 🔗 Issue Number

> #154 #160 

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용

작업 내용
- categoryName의 기본값 설정
  - categoryName의 기본값을 "전체"로 설정하여 커뮤니티 목록 조회 시 400 오류 해결 시도
- IncorrectResultSizeDataAccessException 예외 처리 개선
  - 댓글 조회 중 발생할 수 있는 IncorrectResultSizeDataAccessException 예외 발생 시, 요청 파라미터(relatedType, relatedNumber, userNumber)와 함께 상세 로그를 추가
- getList 및 getListPage 메서드 수정
  - 댓글 목록 반환 로직을 개선:
  - getList: 댓글이 없을 경우 Collections.emptyList() 반환.
  - getListPage: 댓글이 없을 경우 Page.empty() 반환.
  - 빈 결과를 안전하게 처리할 수 있도록 방어 코드 추가.

## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
