### PR TITLE
[TMO-58] 여행 날짜 필드 및 관련 로직 수정

### DIFF
--- a/src/main/java/swyp/swyp6_team7/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/dto/BookmarkResponse.java
@@ -4,16 +4,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import swyp.swyp6_team7.member.entity.Users;
-import swyp.swyp6_team7.travel.domain.Travel;
-import swyp.swyp6_team7.travel.dto.response.TravelListResponseDto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -29,8 +22,6 @@ public class BookmarkResponse {
     private int maxPerson;              // 최대 참가 인원 수
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate registerDue;
     private boolean isBookmarked;       // 북마크 여부
 
 }

--- a/src/main/java/swyp/swyp6_team7/bookmark/service/BookmarkService.java
+++ b/src/main/java/swyp/swyp6_team7/bookmark/service/BookmarkService.java
@@ -121,7 +121,6 @@ public class BookmarkService {
                                         currentApplicants,
                                         travel.getMaxPerson(),
                                         travel.getCreatedAt(),
-                                        travel.getDueDate(),
                                         true
                                 );
                             }).orElse(null); // 삭제된 여행에 대한 북마크는 null 반환

--- a/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
+++ b/src/main/java/swyp/swyp6_team7/enrollment/service/EnrollmentService.java
@@ -28,12 +28,10 @@ public class EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
     private final TravelRepository travelRepository;
     private final CompanionRepository companionRepository;
-
     private final NotificationService notificationService;
 
 
     @Transactional
-
     public void create(EnrollmentCreateRequest request, int requestUserNumber, LocalDate nowDate) {
 
         Travel targetTravel = travelRepository.findByNumber(request.getTravelNumber())
@@ -42,7 +40,7 @@ public class EnrollmentService {
                     return new IllegalArgumentException("존재하지 않는 여행 콘텐츠입니다.");
                 });
 
-        if (!targetTravel.availableForEnroll(nowDate)) {
+        if (!targetTravel.availableForEnroll()) {
             log.warn("Enrollment create - 참가 신청 할 수 없는 상태의 여행입니다. travelNumber: {}", targetTravel.getNumber());
             throw new IllegalArgumentException("참가 신청 할 수 없는 상태의 여행입니다.");
         }
@@ -157,7 +155,6 @@ public class EnrollmentService {
 
         //알림
         notificationService.createRejectNotification(targetTravel, enrollment.getUserNumber());
-
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
+++ b/src/main/java/swyp/swyp6_team7/notification/dto/TravelNotificationDto.java
@@ -1,29 +1,19 @@
 package swyp.swyp6_team7.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import swyp.swyp6_team7.notification.entity.TravelNotification;
-
-import java.time.LocalDate;
 
 @Getter
 public class TravelNotificationDto extends NotificationDto {
 
     private Integer travelNumber;
-
     private String travelTitle;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate travelDueDate;
-
     private Boolean travelHostUser;
-
 
     public TravelNotificationDto(TravelNotification notification) {
         super(notification);
         this.travelNumber = notification.getTravelNumber();
         this.travelTitle = notification.getTravelTitle();
-        this.travelDueDate = notification.getTravelDueDate();
         this.travelHostUser = notification.getTravelHost();
     }
 

--- a/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
+++ b/src/main/java/swyp/swyp6_team7/notification/entity/TravelNotification.java
@@ -7,9 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -25,9 +23,6 @@ public class TravelNotification extends Notification {
     @Column(name = "travel_title", length = 20)
     private String travelTitle;
 
-    @Column(name = "travel_due_date")
-    private LocalDate travelDueDate;
-
     @Column(name = "travel_host")
     private Boolean travelHost;
 
@@ -35,15 +30,13 @@ public class TravelNotification extends Notification {
     public TravelNotification(
             Long number, LocalDateTime createdAt, Integer receiverNumber,
             String title, String content, Boolean isRead,
-            Integer travelNumber, String travelTitle, LocalDate travelDueDate, Boolean travelHost
+            Integer travelNumber, String travelTitle, Boolean travelHost
     ) {
         super(number, createdAt, receiverNumber, title, content, isRead);
         this.travelNumber = travelNumber;
         this.travelTitle = travelTitle;
-        this.travelDueDate = travelDueDate;
         this.travelHost = travelHost;
     }
-
 
     @Override
     public String toString() {
@@ -54,11 +47,9 @@ public class TravelNotification extends Notification {
                 ", title='" + super.getTitle() + '\'' +
                 ", content='" + super.getContent() + '\'' +
                 ", isRead=" + super.getIsRead() +
-                "travelNumber=" + travelNumber +
+                ", travelNumber=" + travelNumber +
                 ", travelTitle='" + travelTitle + '\'' +
-                ", travelDueDate=" + travelDueDate +
                 ", travelHost=" + travelHost +
                 '}';
     }
-
 }

--- a/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
+++ b/src/main/java/swyp/swyp6_team7/notification/util/NotificationMaker.java
@@ -47,7 +47,6 @@ public class NotificationMaker {
                 .content(messageType.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
                 .travelHost(true)
                 .isRead(false)
                 .build();
@@ -60,7 +59,6 @@ public class NotificationMaker {
                 .content(messageType.getContent(targetTravel.getTitle()))
                 .travelNumber(targetTravel.getNumber())
                 .travelTitle(targetTravel.getTitle())
-                .travelDueDate(targetTravel.getDueDate())
                 .travelHost(false)
                 .isRead(false)
                 .build();

--- a/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
+++ b/src/main/java/swyp/swyp6_team7/travel/controller/TravelController.java
@@ -1,11 +1,11 @@
 package swyp.swyp6_team7.travel.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import swyp.swyp6_team7.global.utils.ClientIpAddressUtil;
 import swyp.swyp6_team7.global.utils.api.ApiResponse;
@@ -31,13 +31,13 @@ public class TravelController {
 
     @PostMapping("/api/travel")
     public ApiResponse<TravelCreateResponse> create(
-            @RequestBody @Validated TravelCreateRequest request,
+            @RequestBody @Valid TravelCreateRequest request,
             @RequireUserNumber Integer userNumber
     ) {
-        logger.info("Travel 생성 요청 - userId: {}", userNumber);
+        logger.info("Travel 생성 요청: userId={}", userNumber);
 
         Travel createdTravel = travelService.create(request, userNumber);
-        logger.info("Travel 생성 완료 - userId: {}, createdTravel: {}", userNumber, createdTravel);
+        logger.info("Travel 생성 완료: userId={}, createdTravel={}", userNumber, createdTravel);
 
         return ApiResponse.success(new TravelCreateResponse(createdTravel.getNumber()));
     }
@@ -77,13 +77,13 @@ public class TravelController {
     @PutMapping("/api/travel/{travelNumber}")
     public ApiResponse<TravelUpdateResponse> update(
             @PathVariable("travelNumber") int travelNumber,
-            @RequestBody TravelUpdateRequest request,
+            @RequestBody @Valid TravelUpdateRequest request,
             @RequireUserNumber Integer userNumber
     ) {
-        logger.info("Travel 수정 요청 - userId: {}, travelNumber: {}", userNumber, travelNumber);
+        logger.info("Travel 수정 요청: userId={}, travelNumber={}", userNumber, travelNumber);
 
         Travel updatedTravel = travelService.update(travelNumber, request, userNumber);
-        logger.info("Travel 수정 요청 - userId: {}, updatedTravel: {}", userNumber, updatedTravel);
+        logger.info("Travel 수정 요청: userId={}, updatedTravel={}", userNumber, updatedTravel);
 
         return ApiResponse.success(new TravelUpdateResponse(updatedTravel.getNumber()));
     }
@@ -93,10 +93,10 @@ public class TravelController {
             @PathVariable("travelNumber") int travelNumber,
             @RequireUserNumber Integer userNumber
     ) {
-        logger.info("Travel 삭제 요청 - userId: {}, travelNumber: {}", userNumber, travelNumber);
+        logger.info("Travel 삭제 요청: userId={}, travelNumber={}", userNumber, travelNumber);
 
         travelService.delete(travelNumber, userNumber);
-        logger.info("Travel 삭제 완료 - userId: {}, travelNumber: {}", userNumber, travelNumber);
+        logger.info("Travel 삭제 완료: userId={}, travelNumber={}", userNumber, travelNumber);
 
         return ApiResponse.success(null);
     }

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -10,6 +10,7 @@ import swyp.swyp6_team7.member.entity.DeletedUsers;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.domain.TravelTag;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +46,14 @@ public class Travel {
     //여행지
     @Column(name = "travel_location", length = 20)
     private String locationName;
+
+    //여행 시작 일자
+    @Column(name = "travel_start_date", nullable = false)
+    private LocalDate startDate;
+
+    //여행 종료 일자
+    @Column(name = "travel_end_date", nullable = false)
+    private LocalDate endDate;
 
     //제목
     @Column(name = "travel_title", length = 20)
@@ -94,8 +103,8 @@ public class Travel {
 
     @Builder
     public Travel(
-            int number, int userNumber, LocalDateTime createdAt,
-            Location location, String locationName, String title, String details, int viewCount,
+            int number, int userNumber, LocalDateTime createdAt, Location location, String locationName,
+            LocalDate startDate, LocalDate endDate, String title, String details, int viewCount,
             int maxPerson, GenderType genderType, PeriodType periodType, TravelStatus status,
             LocalDateTime enrollmentsLastViewedAt, List<Tag> tags, DeletedUsers deletedUser
     ) {
@@ -104,6 +113,8 @@ public class Travel {
         this.createdAt = createdAt;
         this.location = location;
         this.locationName = locationName;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.title = title;
         this.details = details;
         this.viewCount = viewCount;
@@ -127,13 +138,15 @@ public class Travel {
     }
 
     public static Travel create(
-            int userNumber, Location location, String title, String details, int maxPerson,
-            String genderType, String periodType, List<Tag> tags
+            int userNumber, Location location, LocalDate startDate, LocalDate endDate,
+            String title, String details, int maxPerson, String genderType, String periodType, List<Tag> tags
     ) {
         return Travel.builder()
                 .userNumber(userNumber)
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(startDate)
+                .endDate(endDate)
                 .title(title)
                 .details(details)
                 .viewCount(0)
@@ -146,17 +159,18 @@ public class Travel {
     }
 
     public Travel update(
-            Location location, String title, String details, int maxPerson,
-            String genderType, String periodType, Boolean status, List<TravelTag> tags
+            Location location, LocalDate startDate, LocalDate endDate,
+            String title, String details, int maxPerson, String genderType, String periodType, List<TravelTag> tags
     ) {
         this.location = location;
         this.locationName = location.getLocationName();
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.title = title;
         this.details = details;
         this.maxPerson = maxPerson;
         this.genderType = GenderType.of(genderType);
         this.periodType = PeriodType.of(periodType);
-        this.status = TravelStatus.convertCompletionToStatus(status);
         this.travelTags = tags;
         return this;
     }
@@ -204,7 +218,9 @@ public class Travel {
                 "number=" + number +
                 ", userNumber=" + userNumber +
                 ", createdAt=" + createdAt +
-                ", location='" + locationName + '\'' +
+                ", locationName='" + locationName + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
                 ", title='" + title + '\'' +
                 ", details='" + details + '\'' +
                 ", viewCount=" + viewCount +
@@ -214,10 +230,6 @@ public class Travel {
                 ", status=" + status +
                 ", enrollmentsLastViewedAt=" + enrollmentsLastViewedAt +
                 '}';
-    }
-
-    public Long getLocationId() {
-        return location != null ? location.getId() : null;
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
+++ b/src/main/java/swyp/swyp6_team7/travel/domain/Travel.java
@@ -10,7 +10,6 @@ import swyp.swyp6_team7.member.entity.DeletedUsers;
 import swyp.swyp6_team7.tag.domain.Tag;
 import swyp.swyp6_team7.tag.domain.TravelTag;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,10 +68,6 @@ public class Travel {
     @Column(name = "travel_gender", nullable = false, length = 20)
     private GenderType genderType;
 
-    //모집 종료 일시
-    @Column(name = "travel_due_date")
-    private LocalDate dueDate;
-
     //여행 기간 카테고리
     @Enumerated(EnumType.STRING)
     @Column(name = "travel_period", nullable = false, length = 20)
@@ -101,9 +96,8 @@ public class Travel {
     public Travel(
             int number, int userNumber, LocalDateTime createdAt,
             Location location, String locationName, String title, String details, int viewCount,
-            int maxPerson, GenderType genderType, LocalDate dueDate,
-            PeriodType periodType, TravelStatus status, LocalDateTime enrollmentsLastViewedAt,
-            List<Tag> tags, DeletedUsers deletedUser
+            int maxPerson, GenderType genderType, PeriodType periodType, TravelStatus status,
+            LocalDateTime enrollmentsLastViewedAt, List<Tag> tags, DeletedUsers deletedUser
     ) {
         this.number = number;
         this.userNumber = userNumber;
@@ -115,7 +109,6 @@ public class Travel {
         this.viewCount = viewCount;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
-        this.dueDate = dueDate;
         this.periodType = periodType;
         this.status = status;
         this.enrollmentsLastViewedAt = enrollmentsLastViewedAt;
@@ -135,7 +128,7 @@ public class Travel {
 
     public static Travel create(
             int userNumber, Location location, String title, String details, int maxPerson,
-            String genderType, LocalDate dueDate, String periodType, List<Tag> tags
+            String genderType, String periodType, List<Tag> tags
     ) {
         return Travel.builder()
                 .userNumber(userNumber)
@@ -146,7 +139,6 @@ public class Travel {
                 .viewCount(0)
                 .maxPerson(maxPerson)
                 .genderType(GenderType.of(genderType))
-                .dueDate(dueDate)
                 .periodType(PeriodType.of(periodType))
                 .status(TravelStatus.IN_PROGRESS)
                 .tags(tags)
@@ -155,8 +147,7 @@ public class Travel {
 
     public Travel update(
             Location location, String title, String details, int maxPerson,
-            String genderType, LocalDate dueDate, String periodType, Boolean status,
-            List<TravelTag> tags
+            String genderType, String periodType, Boolean status, List<TravelTag> tags
     ) {
         this.location = location;
         this.locationName = location.getLocationName();
@@ -164,7 +155,6 @@ public class Travel {
         this.details = details;
         this.maxPerson = maxPerson;
         this.genderType = GenderType.of(genderType);
-        this.dueDate = dueDate;
         this.periodType = PeriodType.of(periodType);
         this.status = TravelStatus.convertCompletionToStatus(status);
         this.travelTags = tags;
@@ -179,11 +169,8 @@ public class Travel {
         this.status = TravelStatus.DELETED;
     }
 
-    public boolean availableForEnroll(LocalDate checkDateTime) {
+    public boolean availableForEnroll() {
         if (this.status != TravelStatus.IN_PROGRESS) {
-            return false;
-        }
-        if (this.dueDate.isBefore(checkDateTime)) {
             return false;
         }
         return true;
@@ -223,7 +210,6 @@ public class Travel {
                 ", viewCount=" + viewCount +
                 ", maxPerson=" + maxPerson +
                 ", genderType=" + genderType +
-                ", dueDate=" + dueDate +
                 ", periodType=" + periodType +
                 ", status=" + status +
                 ", enrollmentsLastViewedAt=" + enrollmentsLastViewedAt +

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForMemberDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForMemberDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,7 +23,6 @@ public class TravelRecommendForMemberDto {
     private int nowPerson;
     private int maxPerson;
     private LocalDateTime createdAt;
-    private LocalDate registerDue;
     private int preferredNumber;
     private boolean bookmarked;
 
@@ -32,7 +30,7 @@ public class TravelRecommendForMemberDto {
     public TravelRecommendForMemberDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, int preferredNumber, boolean isBookmarked
+            LocalDateTime createdAt, int preferredNumber, boolean isBookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -43,7 +41,6 @@ public class TravelRecommendForMemberDto {
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
-        this.registerDue = registerDue;
         this.preferredNumber = preferredNumber;
         this.bookmarked = isBookmarked;
     }
@@ -62,7 +59,6 @@ public class TravelRecommendForMemberDto {
         this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDate();
         this.bookmarked = isBookmarked;
     }
 
@@ -83,7 +79,6 @@ public class TravelRecommendForMemberDto {
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", createdAt=" + createdAt +
-                ", registerDue=" + registerDue +
                 ", preferredNumber=" + preferredNumber +
                 ", bookmarked=" + bookmarked +
                 '}';

--- a/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForNonMemberDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/TravelRecommendForNonMemberDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,14 +23,12 @@ public class TravelRecommendForNonMemberDto {
     private int nowPerson;
     private int maxPerson;
     private LocalDateTime createdAt;
-    private LocalDate registerDue;
     private int bookmarkCount;
 
     @Builder
     public TravelRecommendForNonMemberDto(
             int travelNumber, String title, String location, int userNumber, String userName,
-            List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, int bookmarkCount
+            List<String> tags, int nowPerson, int maxPerson, LocalDateTime createdAt, int bookmarkCount
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -42,7 +39,6 @@ public class TravelRecommendForNonMemberDto {
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
-        this.registerDue = registerDue;
         this.bookmarkCount = bookmarkCount;
     }
 
@@ -60,7 +56,6 @@ public class TravelRecommendForNonMemberDto {
         this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDate();
         this.bookmarkCount = bookmarkCount;
     }
 
@@ -76,7 +71,6 @@ public class TravelRecommendForNonMemberDto {
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", createdAt=" + createdAt +
-                ", registerDue=" + registerDue +
                 ", bookmarkCount=" + bookmarkCount +
                 '}';
     }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,35 +18,35 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TravelCreateRequest {
 
-    private String locationName;
-    // todo: 시작, 종료 날짜 필드 추가
+    private String locationName; // 여행지 이름
+    @NotNull
+    private LocalDate startDate; // 여행 시작 일자
+    @NotNull
+    private LocalDate endDate; // 여행 종료 일자
     @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
-    private String title;
-    private String details;
+    private String title; // 여행 게시글 제목
+    private String details; // 여행 게시글 본문
     @PositiveOrZero(message = "여행 참가 최대 인원은 0보다 작을 수 없습니다.")
     private int maxPerson;
-    private String genderType;
-    private String periodType;
+    private String genderType; // 모집 성별 타입
+    private String periodType; // 여행 기간 타입
     @NotNull
     @Builder.Default
-    private List<String> tags = new ArrayList<>();
-    @NotNull
-    private boolean completionStatus;
-
+    private List<String> tags = new ArrayList<>(); // 게시글 태그
 
     public TravelCreateRequest(
-            String locationName, String title, String details,
-            int maxPerson, String genderType, String periodType,
-            List<String> tags, boolean completionStatus
+            String locationName, LocalDate startDate, LocalDate endDate, String title, String details,
+            int maxPerson, String genderType, String periodType, List<String> tags
     ) {
         this.locationName = locationName;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.title = title;
         this.details = details;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
         this.periodType = periodType;
         this.tags = tags;
-        this.completionStatus = completionStatus;
     }
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelCreateRequest.java
@@ -1,6 +1,5 @@
 package swyp.swyp6_team7.travel.dto.request;
 
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -9,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,14 +18,13 @@ import java.util.List;
 public class TravelCreateRequest {
 
     private String locationName;
+    // todo: 시작, 종료 날짜 필드 추가
     @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
     private String title;
     private String details;
     @PositiveOrZero(message = "여행 참가 최대 인원은 0보다 작을 수 없습니다.")
     private int maxPerson;
     private String genderType;
-    @FutureOrPresent(message = "여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다.")
-    private LocalDate dueDate;
     private String periodType;
     @NotNull
     @Builder.Default
@@ -38,7 +35,7 @@ public class TravelCreateRequest {
 
     public TravelCreateRequest(
             String locationName, String title, String details,
-            int maxPerson, String genderType, LocalDate dueDate, String periodType,
+            int maxPerson, String genderType, String periodType,
             List<String> tags, boolean completionStatus
     ) {
         this.locationName = locationName;
@@ -46,7 +43,6 @@ public class TravelCreateRequest {
         this.details = details;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
-        this.dueDate = dueDate;
         this.periodType = periodType;
         this.tags = tags;
         this.completionStatus = completionStatus;

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
@@ -1,12 +1,10 @@
 package swyp.swyp6_team7.travel.dto.request;
 
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,14 +15,13 @@ import java.util.List;
 public class TravelUpdateRequest {
 
     private String locationName;
+    // todo: 시작, 종료 날짜 필드 추가
     @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
     private String title;
     private String details;
     @PositiveOrZero(message = "여행 참가 최대 인원은 0보다 작을 수 없습니다.")
     private int maxPerson;
     private String genderType;
-    @FutureOrPresent(message = "여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다.")
-    private LocalDate dueDate;
     private String periodType;
     @NotNull
     @Builder.Default

--- a/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/request/TravelUpdateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +16,10 @@ import java.util.List;
 public class TravelUpdateRequest {
 
     private String locationName;
-    // todo: 시작, 종료 날짜 필드 추가
+    @NotNull
+    private LocalDate startDate;
+    @NotNull
+    private LocalDate endDate;
     @Size(max = 20, message = "여행 제목은 최대 20자 입니다.")
     private String title;
     private String details;
@@ -26,7 +30,5 @@ public class TravelUpdateRequest {
     @NotNull
     @Builder.Default
     private List<String> tags = new ArrayList<>();
-    @NotNull
-    private Boolean completionStatus;
 
 }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,8 +31,6 @@ public class TravelDetailResponse {
     private int nowPerson;      //현재 모집 인원
     private int maxPerson;      //최대 모집 인원
     private String genderType;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate dueDate;
     private String periodType;
     private List<String> tags;
     private String postStatus;
@@ -44,8 +41,7 @@ public class TravelDetailResponse {
     public TravelDetailResponse(
             int travelNumber, int userNumber, String userName, String userAgeGroup, String profileUrl, LocalDateTime createdAt,
             String location, String title, String details, int viewCount, int enrollCount, int bookmarkCount,
-            int nowPerson, int maxPerson, String genderType, LocalDate dueDate, String periodType,
-            List<String> tags, String postStatus
+            int nowPerson, int maxPerson, String genderType, String periodType, List<String> tags, String postStatus
     ) {
         this.travelNumber = travelNumber;
         this.userNumber = userNumber;
@@ -62,7 +58,6 @@ public class TravelDetailResponse {
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.genderType = genderType;
-        this.dueDate = dueDate;
         this.periodType = periodType;
         this.tags = tags;
         this.postStatus = postStatus;
@@ -86,7 +81,6 @@ public class TravelDetailResponse {
         this.nowPerson = travelDetail.getCompanionCount();
         this.maxPerson = travelDetail.getTravel().getMaxPerson();
         this.genderType = travelDetail.getTravel().getGenderType().toString();
-        this.dueDate = travelDetail.getTravel().getDueDate();
         this.periodType = travelDetail.getTravel().getPeriodType().toString();
         this.tags = travelDetail.getTags();
         this.postStatus = travelDetail.getTravel().getStatus().toString();
@@ -115,7 +109,6 @@ public class TravelDetailResponse {
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", genderType='" + genderType + '\'' +
-                ", dueDate=" + dueDate +
                 ", periodType='" + periodType + '\'' +
                 ", tags=" + tags +
                 ", postStatus='" + postStatus + '\'' +

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelDetailResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.dto.TravelDetailDto;
 import swyp.swyp6_team7.travel.dto.TravelDetailLoginMemberRelatedDto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -23,6 +24,10 @@ public class TravelDetailResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
     private String location;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
     private String title;
     private String details;
     private int viewCount;      //조회수
@@ -40,8 +45,8 @@ public class TravelDetailResponse {
     @Builder
     public TravelDetailResponse(
             int travelNumber, int userNumber, String userName, String userAgeGroup, String profileUrl, LocalDateTime createdAt,
-            String location, String title, String details, int viewCount, int enrollCount, int bookmarkCount,
-            int nowPerson, int maxPerson, String genderType, String periodType, List<String> tags, String postStatus
+            LocalDate startDate, LocalDate endDate, String location, String title, String details, int viewCount, int enrollCount,
+            int bookmarkCount, int nowPerson, int maxPerson, String genderType, String periodType, List<String> tags, String postStatus
     ) {
         this.travelNumber = travelNumber;
         this.userNumber = userNumber;
@@ -50,6 +55,8 @@ public class TravelDetailResponse {
         this.profileUrl = profileUrl;
         this.createdAt = createdAt;
         this.location = location;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.title = title;
         this.details = details;
         this.viewCount = viewCount;
@@ -73,6 +80,8 @@ public class TravelDetailResponse {
         this.profileUrl = hostProfileImageUrl;
         this.createdAt = travelDetail.getTravel().getCreatedAt();
         this.location = travelDetail.getTravel().getLocationName();
+        this.startDate = travelDetail.getTravel().getStartDate();
+        this.endDate = travelDetail.getTravel().getEndDate();
         this.title = travelDetail.getTravel().getTitle();
         this.details = travelDetail.getTravel().getDetails();
         this.viewCount = travelDetail.getTravel().getViewCount();
@@ -101,6 +110,8 @@ public class TravelDetailResponse {
                 ", profileUrl='" + profileUrl + '\'' +
                 ", createdAt=" + createdAt +
                 ", location='" + location + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
                 ", title='" + title + '\'' +
                 ", details='" + details + '\'' +
                 ", viewCount=" + viewCount +

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelListResponseDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelListResponseDto.java
@@ -7,10 +7,7 @@ import lombok.Getter;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,8 +25,6 @@ public class TravelListResponseDto {
     private int maxPerson;              // 최대 참가 인원 수
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate registerDue;
     private boolean isBookmarked;       // 북마크 여부
 
 
@@ -44,7 +39,6 @@ public class TravelListResponseDto {
                 currentApplicants,
                 travel.getMaxPerson(),
                 travel.getCreatedAt(),
-                travel.getDueDate(),
                 isBookmarked
         );
     }

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecentDto.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,8 +27,6 @@ public class TravelRecentDto {
     private int maxPerson;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate registerDue;
     private boolean bookmarked;
 
 
@@ -37,7 +34,7 @@ public class TravelRecentDto {
     public TravelRecentDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int nowPerson, int maxPerson,
-            LocalDateTime createdAt, LocalDate registerDue, boolean isBookmarked
+            LocalDateTime createdAt, boolean isBookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -48,7 +45,6 @@ public class TravelRecentDto {
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
-        this.registerDue = registerDue;
         this.bookmarked = isBookmarked;
     }
 
@@ -66,7 +62,6 @@ public class TravelRecentDto {
         this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDate();
         this.bookmarked = false;
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelRecommendResponse.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.dto.TravelRecommendForMemberDto;
 import swyp.swyp6_team7.travel.dto.TravelRecommendForNonMemberDto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,8 +26,6 @@ public class TravelRecommendResponse {
     private int maxPerson;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate registerDue;
     private boolean bookmarked;
 
     public TravelRecommendResponse(TravelRecommendForMemberDto dto) {
@@ -41,7 +38,6 @@ public class TravelRecommendResponse {
         this.nowPerson = dto.getNowPerson();
         this.maxPerson = dto.getMaxPerson();
         this.createdAt = dto.getCreatedAt();
-        this.registerDue = dto.getRegisterDue();
         this.bookmarked = dto.isBookmarked();
     }
 
@@ -55,7 +51,6 @@ public class TravelRecommendResponse {
         this.nowPerson = dto.getNowPerson();
         this.maxPerson = dto.getMaxPerson();
         this.createdAt = dto.getCreatedAt();
-        this.registerDue = dto.getRegisterDue();
         this.bookmarked = false;
     }
 

--- a/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
+++ b/src/main/java/swyp/swyp6_team7/travel/dto/response/TravelSearchDto.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,8 +27,6 @@ public class TravelSearchDto {
     private int maxPerson;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private LocalDate registerDue;
     private String postStatus;
     private boolean bookmarked;
 
@@ -38,7 +35,7 @@ public class TravelSearchDto {
     public TravelSearchDto(
             int travelNumber, String title, String location, int userNumber, String userName,
             List<String> tags, int maxPerson, int nowPerson,
-            LocalDateTime createdAt, LocalDate registerDue, String postStatus, boolean isBookmarked
+            LocalDateTime createdAt, String postStatus, boolean isBookmarked
     ) {
         this.travelNumber = travelNumber;
         this.title = title;
@@ -49,7 +46,6 @@ public class TravelSearchDto {
         this.nowPerson = nowPerson;
         this.maxPerson = maxPerson;
         this.createdAt = createdAt;
-        this.registerDue = registerDue;
         this.postStatus = postStatus;
         this.bookmarked = isBookmarked;
     }
@@ -69,7 +65,6 @@ public class TravelSearchDto {
         this.nowPerson = companionCount;
         this.maxPerson = travel.getMaxPerson();
         this.createdAt = travel.getCreatedAt();
-        this.registerDue = travel.getDueDate();
         this.postStatus = travel.getStatus().getName();
         this.bookmarked = false;
     }
@@ -91,7 +86,6 @@ public class TravelSearchDto {
                 ", nowPerson=" + nowPerson +
                 ", maxPerson=" + maxPerson +
                 ", createdAt=" + createdAt +
-                ", registerDue=" + registerDue +
                 ", postStatus='" + postStatus + '\'' +
                 ", bookmarked=" + bookmarked +
                 '}';

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -138,13 +138,13 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
-                        statusInProgress()
-                        //travel.dueDate.after(requestDate)
+                        statusInProgress(),
+                        travel.startDate.after(requestDate)
                 )
                 .groupBy(travel.number)
                 .orderBy(
-                        matchingTagCount.desc()
-                        //travel.dueDate.asc()
+                        matchingTagCount.desc(),
+                        travel.title.asc()
                 )
                 .offset(pageRequest.getOffset())
                 .limit(pageRequest.getPageSize())
@@ -170,8 +170,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(bookmark).on(bookmark.userNumber.eq(loginUserNumber)
                         .and(bookmark.travelNumber.eq(travel.number)))
                 .where(
-                        travel.number.in(travels)
-                        //travel.dueDate.after(requestDate)
+                        travel.number.in(travels),
+                        travel.startDate.after(requestDate)
                 )
                 .transform(groupBy(travel.number).list(
                         Projections.constructor(TravelRecommendForMemberDto.class,
@@ -190,8 +190,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusInProgress()
-                        //travel.dueDate.after(requestDate)
+                        statusInProgress(),
+                        travel.startDate.after(requestDate)
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
@@ -210,8 +210,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travelTag.tag, tag)
                 .leftJoin(bookmark).on(bookmark.travelNumber.eq(travel.number))
                 .where(
-                        statusInProgress()
-                        //travel.dueDate.after(requestDate)
+                        statusInProgress(),
+                        travel.startDate.after(requestDate)
                 )
                 .groupBy(travel.number)
                 .orderBy(
@@ -234,8 +234,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusInProgress()
-                        //travel.dueDate.after(requestDate)
+                        statusInProgress(),
+                        travel.startDate.after(requestDate)
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);

--- a/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
+++ b/src/main/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImpl.java
@@ -138,13 +138,13 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travel.travelTags, travelTag)
                 .leftJoin(travelTag.tag, tag)
                 .where(
-                        statusInProgress(),
-                        travel.dueDate.after(requestDate)
+                        statusInProgress()
+                        //travel.dueDate.after(requestDate)
                 )
                 .groupBy(travel.number)
                 .orderBy(
-                        matchingTagCount.desc(),
-                        travel.dueDate.asc()
+                        matchingTagCount.desc()
+                        //travel.dueDate.asc()
                 )
                 .offset(pageRequest.getOffset())
                 .limit(pageRequest.getPageSize())
@@ -170,8 +170,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(bookmark).on(bookmark.userNumber.eq(loginUserNumber)
                         .and(bookmark.travelNumber.eq(travel.number)))
                 .where(
-                        travel.number.in(travels),
-                        travel.dueDate.after(requestDate)
+                        travel.number.in(travels)
+                        //travel.dueDate.after(requestDate)
                 )
                 .transform(groupBy(travel.number).list(
                         Projections.constructor(TravelRecommendForMemberDto.class,
@@ -190,8 +190,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusInProgress(),
-                        travel.dueDate.after(requestDate)
+                        statusInProgress()
+                        //travel.dueDate.after(requestDate)
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
@@ -210,8 +210,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .leftJoin(travelTag.tag, tag)
                 .leftJoin(bookmark).on(bookmark.travelNumber.eq(travel.number))
                 .where(
-                        statusInProgress(),
-                        travel.dueDate.after(requestDate)
+                        statusInProgress()
+                        //travel.dueDate.after(requestDate)
                 )
                 .groupBy(travel.number)
                 .orderBy(
@@ -234,8 +234,8 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                 .select(travel.number.countDistinct())
                 .from(travel)
                 .where(
-                        statusInProgress(),
-                        travel.dueDate.after(requestDate)
+                        statusInProgress()
+                        //travel.dueDate.after(requestDate)
                 );
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
@@ -389,7 +389,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
 
     private List<OrderSpecifier<?>> getOrderSpecifier(TravelSearchSortingType sortingType) {
         if (sortingType == null) {
-            return List.of(travel.dueDate.asc(), travel.createdAt.desc());
+            return List.of(travel.createdAt.desc());
         }
         switch (sortingType) {
             case RECOMMEND:
@@ -399,7 +399,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
             case CREATED_AT_ASC:
                 return List.of(travel.createdAt.asc());
             default:
-                return List.of(travel.dueDate.asc());
+                return List.of(travel.createdAt.desc());
         }
     }
 
@@ -416,7 +416,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                     .otherwise(travels.size())
                     .asc();
         } else {
-            return travel.dueDate.asc();
+            return travel.createdAt.desc();
         }
     }
 }

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelListService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelListService.java
@@ -72,7 +72,6 @@ public class TravelListService {
                     currentApplicants,
                     travel.getMaxPerson(),
                     travel.getCreatedAt(),
-                    travel.getDueDate(),
                     isBookmarked
             );
         }

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -36,6 +36,8 @@ import java.util.List;
 public class TravelService {
 
     public static final int TRAVEL_TAG_MAX_COUNT = 5;
+
+    // TODO: 링크 수정
     private final static String DEFAULT_PROFILE_IMAGE_URL = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
 
     private final TravelTagService travelTagService;
@@ -56,7 +58,7 @@ public class TravelService {
 
         Travel travel = Travel.create(loginUserNumber, location,
                 request.getTitle(), request.getDetails(), request.getMaxPerson(),
-                request.getGenderType(), request.getDueDate(), request.getPeriodType(), tags);
+                request.getGenderType(), request.getPeriodType(), tags);
 
         return travelRepository.save(travel);
     }
@@ -100,7 +102,6 @@ public class TravelService {
         }
 
         // 주최자 프로필 이미지 (만약 못찾을 경우 default 프로필 이미지로 설정)
-        // TODO: DEFAULT_PROFILE_IMAGE_URL 수정
         String hostProfileImageUrl = imageRepository.findUrlByRelatedUserNumber(travelDetail.getHostNumber())
                 .orElse(DEFAULT_PROFILE_IMAGE_URL);
 
@@ -162,7 +163,7 @@ public class TravelService {
 
         Travel updatedTravel = travel.update(
                 location, request.getTitle(), request.getDetails(), request.getMaxPerson(),
-                request.getGenderType(), request.getDueDate(), request.getPeriodType(), request.getCompletionStatus(),
+                request.getGenderType(), request.getPeriodType(), request.getCompletionStatus(),
                 travelTags
         );
 

--- a/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
+++ b/src/main/java/swyp/swyp6_team7/travel/service/TravelService.java
@@ -9,6 +9,7 @@ import swyp.swyp6_team7.comment.domain.Comment;
 import swyp.swyp6_team7.comment.repository.CommentRepository;
 import swyp.swyp6_team7.comment.service.CommentService;
 import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
+import swyp.swyp6_team7.global.exception.MoingApplicationException;
 import swyp.swyp6_team7.image.repository.ImageRepository;
 import swyp.swyp6_team7.location.domain.Location;
 import swyp.swyp6_team7.location.domain.LocationType;
@@ -26,7 +27,9 @@ import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Slf4j
@@ -52,13 +55,14 @@ public class TravelService {
 
     @Transactional
     public Travel create(TravelCreateRequest request, int loginUserNumber) {
+        validateTravelDaysRange(request.getStartDate(), request.getEndDate());  // 여행 기간 검증
 
         Location location = getLocation(request.getLocationName());
         List<Tag> tags = getTags(request.getTags());
 
         Travel travel = Travel.create(loginUserNumber, location,
-                request.getTitle(), request.getDetails(), request.getMaxPerson(),
-                request.getGenderType(), request.getPeriodType(), tags);
+                request.getStartDate(), request.getEndDate(), request.getTitle(), request.getDetails(),
+                request.getMaxPerson(), request.getGenderType(), request.getPeriodType(), tags);
 
         return travelRepository.save(travel);
     }
@@ -78,17 +82,26 @@ public class TravelService {
                             .locationName(locationName)
                             .locationType(LocationType.UNKNOWN) // UNKNOWN으로 설정
                             .build();
-                    log.info("Location 생성 - locationName: {}", newLocation.getLocationName());
+                    log.info("Location 생성: locationName={}", newLocation.getLocationName());
                     return locationRepository.save(newLocation);
                 });
         return location;
+    }
+
+    private void validateTravelDaysRange(LocalDate startDate, LocalDate endDate) {
+        // 여행 기간이 90일을 초과하면 예외 발생
+        long travelDays = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+
+        if (travelDays > 90) {
+            throw new MoingApplicationException("여행 기간은 90일을 초과할 수 없습니다.");
+        }
     }
 
     public TravelDetailResponse getDetailsByNumber(int travelNumber) {
 
         boolean travelExistence = travelRepository.existsTravelByNumber(travelNumber);
         if (!travelExistence) {
-            log.warn("해당하는 여행을 찾을 수 없습니다. travelNumber: {}", travelNumber);
+            log.warn("해당하는 여행을 찾을 수 없습니다: travelNumber={}", travelNumber);
             throw new IllegalArgumentException("해당하는 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber);
         }
 
@@ -97,7 +110,7 @@ public class TravelService {
 
         // 여행 상태가 삭제인 경우 예외 처리
         if (travelDetail.getTravelStatus() == TravelStatus.DELETED) {
-            log.warn("Deleted 상태의 여행 콘텐츠는 상세 조회할 수 없습니다 - travelNumber: {}", travelNumber);
+            log.warn("Deleted 상태의 여행 콘텐츠는 상세 조회할 수 없습니다: travelNumber={}", travelNumber);
             throw new IllegalArgumentException("Deleted 상태의 여행 콘텐츠입니다.");
         }
 
@@ -119,7 +132,7 @@ public class TravelService {
         // DRAFT 여부 체크
         if (postStatus.equals(TravelStatus.DRAFT.getName())) {
             if (hostNumber != requestUserNumber) {
-                log.warn("DRAFT 상태의 여행 조회 권한이 없습니다. - travelNumber: {}, requestUser: {}", travelNumber, requestUserNumber);
+                log.warn("DRAFT 상태의 여행 조회 권한이 없습니다:  travelNumber={}, requestUser={}", travelNumber, requestUserNumber);
                 throw new IllegalArgumentException("DRAFT 상태의 여행 조회는 작성자만 가능합니다.");
             }
         }
@@ -150,21 +163,21 @@ public class TravelService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber));
 
         if (travel.getUserNumber() != requestUserNumber) {
-            log.warn("여행 수정 권한이 없습니다. - travelNumber: {}, requestUser: {}", travelNumber, requestUserNumber);
+            log.warn("여행 수정 권한이 없습니다: travelNumber={}, requestUser={}", travelNumber, requestUserNumber);
             throw new IllegalArgumentException("여행 수정 권한이 없습니다.");
         }
 
-        Location location = getLocation(request.getLocationName());
+        validateTravelDaysRange(request.getStartDate(), request.getEndDate());  // 여행 기간 검증
 
+        Location location = getLocation(request.getLocationName());
         List<String> requestTagsName = request.getTags().stream()
                 .distinct().limit(TRAVEL_TAG_MAX_COUNT)
                 .toList();
         List<TravelTag> travelTags = travelTagService.update(travel, requestTagsName);
 
-        Travel updatedTravel = travel.update(
-                location, request.getTitle(), request.getDetails(), request.getMaxPerson(),
-                request.getGenderType(), request.getPeriodType(), request.getCompletionStatus(),
-                travelTags
+        Travel updatedTravel = travel.update(location, request.getStartDate(), request.getEndDate(),
+                request.getTitle(), request.getDetails(), request.getMaxPerson(), request.getGenderType(),
+                request.getPeriodType(), travelTags
         );
 
         return updatedTravel;
@@ -176,7 +189,7 @@ public class TravelService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다. - travelNumber: " + travelNumber));
 
         if (travel.getUserNumber() != requestUserNumber) {
-            log.warn("여행 삭제 권한이 없습니다. - travelNumber: {}, requestUser: {}", travelNumber, requestUserNumber);
+            log.warn("여행 삭제 권한이 없습니다: travelNumber={}, requestUser={}", travelNumber, requestUserNumber);
             throw new IllegalArgumentException("여행 삭제 권한이 없습니다.");
         }
 
@@ -194,7 +207,7 @@ public class TravelService {
 
     public LocalDateTime getEnrollmentsLastViewedAt(int travelNumber) {
         if (!travelRepository.existsTravelByNumber(travelNumber)) {
-            log.warn("Enrollment LastViewed - 존재하지 않는 여행 콘텐츠입니다. travelNumber: {}", travelNumber);
+            log.warn("존재하지 않는 여행 콘텐츠입니다: travelNumber={}", travelNumber);
             throw new IllegalArgumentException("존재하지 않는 여행 콘텐츠입니다.");
         }
 
@@ -204,7 +217,7 @@ public class TravelService {
     @Transactional
     public void updateEnrollmentLastViewedAt(int travelNumber, LocalDateTime lastViewedAt) {
         if (!travelRepository.existsTravelByNumber(travelNumber)) {
-            log.warn("Enrollment LastViewed - 존재하지 않는 여행 콘텐츠입니다. travelNumber: {}", travelNumber);
+            log.warn("존재하지 않는 여행 콘텐츠입니다: travelNumber={}", travelNumber);
             throw new IllegalArgumentException("존재하지 않는 여행 콘텐츠입니다.");
         }
 

--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
@@ -9,11 +9,7 @@ public class TravelRecommendComparator implements Comparator<TravelRecommendForM
     @Override
     public int compare(TravelRecommendForMemberDto o1, TravelRecommendForMemberDto o2) {
         if (o1.getPreferredNumber() == o2.getPreferredNumber()) {
-            // TODO: 조건 수정
-//            if (o1.getRegisterDue().compareTo(o2.getRegisterDue()) == 0) {
-//                return o1.getTitle().compareTo(o2.getTitle());
-//            }
-//            return o1.getRegisterDue().compareTo(o2.getRegisterDue());
+            return o1.getTitle().compareTo(o2.getTitle());
         }
         return -1 * (o1.getPreferredNumber() - o2.getPreferredNumber());
     }

--- a/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
+++ b/src/main/java/swyp/swyp6_team7/travel/util/TravelRecommendComparator.java
@@ -9,10 +9,11 @@ public class TravelRecommendComparator implements Comparator<TravelRecommendForM
     @Override
     public int compare(TravelRecommendForMemberDto o1, TravelRecommendForMemberDto o2) {
         if (o1.getPreferredNumber() == o2.getPreferredNumber()) {
-            if (o1.getRegisterDue().compareTo(o2.getRegisterDue()) == 0) {
-                return o1.getTitle().compareTo(o2.getTitle());
-            }
-            return o1.getRegisterDue().compareTo(o2.getRegisterDue());
+            // TODO: 조건 수정
+//            if (o1.getRegisterDue().compareTo(o2.getRegisterDue()) == 0) {
+//                return o1.getTitle().compareTo(o2.getTitle());
+//            }
+//            return o1.getRegisterDue().compareTo(o2.getRegisterDue());
         }
         return -1 * (o1.getPreferredNumber() - o2.getPreferredNumber());
     }

--- a/src/test/java/swyp/swyp6_team7/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/bookmark/controller/BookmarkControllerTest.java
@@ -23,7 +23,6 @@ import swyp.swyp6_team7.bookmark.dto.BookmarkResponse;
 import swyp.swyp6_team7.bookmark.service.BookmarkService;
 import swyp.swyp6_team7.global.utils.auth.MemberAuthorizeUtil;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -102,7 +101,6 @@ public class BookmarkControllerTest {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
         LocalDateTime createdAt = LocalDateTime.parse("2024-10-02 21:56", dateTimeFormatter);
-        LocalDate registerDue = LocalDate.parse("2025-05-15", dateFormatter);
         BookmarkResponse response = new BookmarkResponse(
                 1,
                 "제목",
@@ -113,7 +111,6 @@ public class BookmarkControllerTest {
                 1,
                 4,
                 createdAt,
-                registerDue,
                 true);
 
         List<BookmarkResponse> responses = List.of(response);

--- a/src/test/java/swyp/swyp6_team7/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/bookmark/service/BookmarkServiceTest.java
@@ -12,24 +12,21 @@ import swyp.swyp6_team7.bookmark.dto.BookmarkResponse;
 import swyp.swyp6_team7.bookmark.entity.Bookmark;
 import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
 import swyp.swyp6_team7.location.domain.Location;
+import swyp.swyp6_team7.location.domain.LocationType;
 import swyp.swyp6_team7.member.entity.Users;
 import swyp.swyp6_team7.member.repository.UserRepository;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-
-import swyp.swyp6_team7.location.domain.LocationType;
 
 public class BookmarkServiceTest {
 
@@ -63,7 +60,6 @@ public class BookmarkServiceTest {
                 .number(101)
                 .location(travelLocation)
                 .locationName(travelLocation.getLocationName())
-                .dueDate(LocalDate.now().plusDays(5))
                 .build();
         Bookmark oldestBookmark = new Bookmark(1, 1, LocalDateTime.now().minusDays(10));
 
@@ -94,7 +90,6 @@ public class BookmarkServiceTest {
                 .number(101)
                 .location(travelLocation)
                 .locationName(travelLocation.getLocationName())
-                .dueDate(LocalDate.now().plusDays(5))
                 .build();
 
 
@@ -149,7 +144,6 @@ public class BookmarkServiceTest {
                 .locationName(travelLocation.getLocationName())
                 .title("Sample Travel")
                 .createdAt(LocalDateTime.now().minusDays(5))
-                .dueDate(LocalDate.now().plusDays(5))
                 .maxPerson(4)
                 .build();
 

--- a/src/test/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImplTest.java
@@ -24,6 +24,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +100,8 @@ class CompanionCustomRepositoryImplTest {
                 .userNumber(3)
                 .maxPerson(2)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(0)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/repository/CompanionCustomRepositoryImplTest.java
@@ -24,7 +24,6 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -101,7 +100,6 @@ class CompanionCustomRepositoryImplTest {
                 .maxPerson(2)
                 .location(location)
                 .viewCount(0)
-                .dueDate(LocalDate.of(2024, 11, 16))
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(TravelStatus.IN_PROGRESS)
@@ -127,5 +125,4 @@ class CompanionCustomRepositoryImplTest {
                 .url(url)
                 .build();
     }
-
 }

--- a/src/test/java/swyp/swyp6_team7/companion/repository/CompanionRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/repository/CompanionRepositoryTest.java
@@ -16,7 +16,6 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,7 +64,6 @@ class CompanionRepositoryTest {
                 .maxPerson(2)
                 .location(location)
                 .viewCount(0)
-                .dueDate(LocalDate.of(2024, 11, 16))
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(TravelStatus.IN_PROGRESS)

--- a/src/test/java/swyp/swyp6_team7/companion/repository/CompanionRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/repository/CompanionRepositoryTest.java
@@ -16,6 +16,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,6 +64,8 @@ class CompanionRepositoryTest {
                 .userNumber(3)
                 .maxPerson(2)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(0)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
@@ -22,7 +22,6 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -101,7 +100,6 @@ class CompanionServiceTest {
                 .maxPerson(2)
                 .location(location)
                 .viewCount(0)
-                .dueDate(LocalDate.of(2024, 11, 16))
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(TravelStatus.IN_PROGRESS)

--- a/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/companion/service/CompanionServiceTest.java
@@ -22,6 +22,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +100,8 @@ class CompanionServiceTest {
                 .userNumber(3)
                 .maxPerson(2)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(0)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
@@ -26,7 +26,6 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -67,7 +66,7 @@ class EnrollmentCustomRepositoryImplTest {
 
         Location location = locationRepository.save(createLocation());
         Travel travel = travelRepository.save(
-                createTravel(3, 2, location, LocalDate.of(2024, 11, 12), TravelStatus.IN_PROGRESS)
+                createTravel(3, 2, location, TravelStatus.IN_PROGRESS)
         );
 
         Enrollment enrollment1 = createEnrollment(travel.getNumber(), user1.getUserNumber(), EnrollmentStatus.PENDING);
@@ -96,7 +95,7 @@ class EnrollmentCustomRepositoryImplTest {
 
         Location location = locationRepository.save(createLocation());
         Travel travel = travelRepository.save(
-                createTravel(3, 2, location, LocalDate.of(2024, 11, 12), TravelStatus.IN_PROGRESS)
+                createTravel(3, 2, location, TravelStatus.IN_PROGRESS)
         );
 
         Enrollment enrollment1 = createEnrollment(travel.getNumber(), user1.getUserNumber(), EnrollmentStatus.PENDING);
@@ -124,7 +123,7 @@ class EnrollmentCustomRepositoryImplTest {
 
         Location location = locationRepository.save(createLocation());
         Travel travel = travelRepository.save(
-                createTravel(3, 2, location, LocalDate.of(2024, 11, 12), TravelStatus.IN_PROGRESS)
+                createTravel(3, 2, location, TravelStatus.IN_PROGRESS)
         );
 
         Enrollment enrollment1 = createEnrollment(travel.getNumber(), user1.getUserNumber(), EnrollmentStatus.PENDING);
@@ -147,7 +146,7 @@ class EnrollmentCustomRepositoryImplTest {
         Users user = userRepository.save(createUser("user1"));
         Location location = locationRepository.save(createLocation());
         Travel travel = travelRepository.save(
-                createTravel(3, 2, location, LocalDate.of(2024, 11, 12), TravelStatus.IN_PROGRESS)
+                createTravel(3, 2, location, TravelStatus.IN_PROGRESS)
         );
 
         Enrollment enrollment1 = enrollmentRepository.save(createEnrollment(travel.getNumber(), user.getUserNumber(), EnrollmentStatus.PENDING));
@@ -186,13 +185,12 @@ class EnrollmentCustomRepositoryImplTest {
                 .build();
     }
 
-    private Travel createTravel(int hostUserNumber, int maxPerson, Location location, LocalDate dueDate, TravelStatus status) {
+    private Travel createTravel(int hostUserNumber, int maxPerson, Location location, TravelStatus status) {
         return Travel.builder()
                 .userNumber(hostUserNumber)
                 .maxPerson(maxPerson)
                 .location(location)
                 .viewCount(0)
-                .dueDate(dueDate)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(status)
@@ -209,5 +207,4 @@ class EnrollmentCustomRepositoryImplTest {
                 .userStatus(UserStatus.ABLE)
                 .build();
     }
-
 }

--- a/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/repository/EnrollmentCustomRepositoryImplTest.java
@@ -26,6 +26,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -190,6 +191,8 @@ class EnrollmentCustomRepositoryImplTest {
                 .userNumber(hostUserNumber)
                 .maxPerson(maxPerson)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(0)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/enrollment/service/EnrollmentServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/enrollment/service/EnrollmentServiceTest.java
@@ -68,7 +68,7 @@ class EnrollmentServiceTest {
     void create() {
         // given
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(1, 2, dueDate, TravelStatus.IN_PROGRESS);
+        Travel targetTravel = createTravel(1, 2, TravelStatus.IN_PROGRESS);
 
         EnrollmentCreateRequest request = EnrollmentCreateRequest.builder()
                 .travelNumber(targetTravel.getNumber())
@@ -91,6 +91,7 @@ class EnrollmentServiceTest {
                 );
     }
 
+    /*
     @DisplayName("create: 마감 날짜를 넘겨 참가 신청할 경우 예외가 발생한다.")
     @Test
     void createWhenNotAvailableForEnroll() {
@@ -114,13 +115,13 @@ class EnrollmentServiceTest {
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("참가 신청 할 수 없는 상태의 여행입니다.");
     }
-
+*/
     @DisplayName("create: 여행 상태가 IN_PROGRESS가 아닌 경우 예외가 발생한다.")
     @Test
     void createWhenNotInProgressStatus() {
         // given
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(1, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(1, 2, TravelStatus.DELETED);
 
         EnrollmentCreateRequest request = EnrollmentCreateRequest.builder()
                 .travelNumber(targetTravel.getNumber())
@@ -173,7 +174,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         Enrollment enrollment = createEnrollment(2, 1, "신청", EnrollmentStatus.PENDING);
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
@@ -200,7 +201,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         Enrollment enrollment = createEnrollment(2, 1, "신청", EnrollmentStatus.PENDING);
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
@@ -223,7 +224,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 0, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 0, TravelStatus.DELETED);
 
         Enrollment enrollment = createEnrollment(2, 1, "신청", EnrollmentStatus.PENDING);
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
@@ -246,7 +247,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         Enrollment enrollment = createEnrollment(2, 1, "신청", EnrollmentStatus.PENDING);
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
@@ -273,7 +274,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         Enrollment enrollment = createEnrollment(2, 1, "신청", EnrollmentStatus.PENDING);
         Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
@@ -296,7 +297,7 @@ class EnrollmentServiceTest {
         // given
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         EnrollmentResponse enrollment1 = EnrollmentResponse.builder()
                 .enrollmentNumber(1)
@@ -329,7 +330,7 @@ class EnrollmentServiceTest {
     void findEnrollmentsWhenNotHostUser() {
         Integer hostUserNumber = 1;
         LocalDate dueDate = LocalDate.of(2024, 11, 11);
-        Travel targetTravel = createTravel(hostUserNumber, 2, dueDate, TravelStatus.DELETED);
+        Travel targetTravel = createTravel(hostUserNumber, 2, TravelStatus.DELETED);
 
         given(travelRepository.findByNumber(any(Integer.class)))
                 .willReturn(Optional.of(targetTravel));
@@ -357,18 +358,16 @@ class EnrollmentServiceTest {
                 .build();
     }
 
-    private Travel createTravel(int hostUserNumber, int maxPerson, LocalDate dueDate, TravelStatus status) {
+    private Travel createTravel(int hostUserNumber, int maxPerson, TravelStatus status) {
         return Travel.builder()
                 .number(1)
                 .userNumber(hostUserNumber)
                 .maxPerson(maxPerson)
                 .location(createLocation())
                 .viewCount(0)
-                .dueDate(dueDate)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(status)
                 .build();
     }
-
 }

--- a/src/test/java/swyp/swyp6_team7/member/service/DeletedMemberServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/member/service/DeletedMemberServiceTest.java
@@ -1,6 +1,5 @@
 package swyp.swyp6_team7.member.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,6 @@ import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -107,6 +105,8 @@ public class DeletedMemberServiceTest {
                 .userNumber(testUser.getUserNumber())
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .title("Test Travel")
                 .genderType(GenderType.MAN_ONLY)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/controller/NotificationControllerTest.java
@@ -18,7 +18,6 @@ import swyp.swyp6_team7.notification.entity.Notification;
 import swyp.swyp6_team7.notification.entity.TravelNotification;
 import swyp.swyp6_team7.notification.service.NotificationService;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -62,7 +61,6 @@ class NotificationControllerTest {
                 .isRead(true)
                 .travelNumber(1)
                 .travelTitle("여행 제목")
-                .travelDueDate(LocalDate.of(2024, 11, 21))
                 .travelHost(true)
                 .build();
         NotificationDto notificationDto2 = new TravelNotificationDto(travelNotification);
@@ -90,8 +88,6 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.success.content[1].isRead").value(true))
                 .andExpect(jsonPath("$.success.content[1].travelNumber").value(1))
                 .andExpect(jsonPath("$.success.content[1].travelTitle").value("여행 제목"))
-                .andExpect(jsonPath("$.success.content[1].travelDueDate").value("2024-11-21"))
                 .andExpect(jsonPath("$.success.content[1].travelHostUser").value(true));
     }
-
 }

--- a/src/test/java/swyp/swyp6_team7/notification/service/CommentNotificationServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/service/CommentNotificationServiceTest.java
@@ -17,7 +17,6 @@ import swyp.swyp6_team7.notification.repository.NotificationRepository;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -196,7 +195,6 @@ class CommentNotificationServiceTest {
                 .userNumber(hostUserNumber)
                 .title("여행Title")
                 .maxPerson(2)
-                .dueDate(LocalDate.of(2024, 11, 16))
                 .build();
     }
 

--- a/src/test/java/swyp/swyp6_team7/notification/service/NotificationServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/notification/service/NotificationServiceTest.java
@@ -15,7 +15,6 @@ import swyp.swyp6_team7.enrollment.repository.EnrollmentRepository;
 import swyp.swyp6_team7.notification.repository.NotificationRepository;
 import swyp.swyp6_team7.travel.domain.Travel;
 
-import java.time.LocalDate;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +44,7 @@ class NotificationServiceTest {
         notificationRepository.deleteAllInBatch();
     }
 
-    @DisplayName("enrollNotification: 주어지는 사용자 번호와 여행 주최자에 대해 신청 생성 알림을 생성한다.")
+    @DisplayName("enrollNotification: 여행 신청자와 주최자가 받을 여행 신청 추가 알림을 생성한다.")
     @Test
     void createEnrollNotification() {
         // given
@@ -57,14 +56,14 @@ class NotificationServiceTest {
 
         // then
         assertThat(notificationRepository.findAll()).hasSize(2)
-                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle")
                 .containsExactlyInAnyOrder(
-                        tuple(1, "여행 신청 알림", "[여행Title]에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.", false, true, 10, "여행Title", LocalDate.of(2024, 11, 16)),
-                        tuple(2, "참가 신청 알림", "[여행Title]에 참가 신청이 완료되었어요. 주최자가 참가를 확정하면 알려드릴게요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16))
+                        tuple(1, "여행 신청 알림", "[여행Title]에 참가 신청자가 있어요. 알림을 눌러 확인해보세요.", false, true, 10, "여행Title"),
+                        tuple(2, "참가 신청 알림", "[여행Title]에 참가 신청이 완료되었어요. 주최자가 참가를 확정하면 알려드릴게요.", false, false, 10, "여행Title")
                 );
     }
 
-    @DisplayName("acceptNotification: 주어지는 사용자 번호에 대해 신청 수락 알림을 생성한다.")
+    @DisplayName("acceptNotification: 신청자가 받을 신청 수락 알림을 생성한다.")
     @Test
     void createAcceptNotification() {
         // given
@@ -76,11 +75,11 @@ class NotificationServiceTest {
 
         // then
         assertThat(notificationRepository.findAll()).hasSize(1)
-                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
-                .contains(tuple(2, "참가 확정 알림", "[여행Title]에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)));
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle")
+                .contains(tuple(2, "참가 확정 알림", "[여행Title]에 참가가 확정되었어요. 멤버 댓글을 통해 인사를 나눠보세요.", false, false, 10, "여행Title"));
     }
 
-    @DisplayName("rejectNotification: 주어지는 사용자 번호에 대해 신청 거절 알림을 생성한다.")
+    @DisplayName("rejectNotification: 신청자가 받을 신청 거절 알림을 생성한다.")
     @Test
     void createRejectNotification() {
         // given
@@ -92,11 +91,11 @@ class NotificationServiceTest {
 
         // then
         assertThat(notificationRepository.findAll()).hasSize(1)
-                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
-                .contains(tuple(2, "참가 거절 알림", "[여행Title]에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)));
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle")
+                .contains(tuple(2, "참가 거절 알림", "[여행Title]에 참가가 아쉽게도 거절되었어요. 다른 여행을 찾아볼까요?", false, false, 10, "여행Title"));
     }
 
-    @DisplayName("companionClosedNotification: 주최자, 참여자, pending 상태의 신청자, 즐겨찾기 사용자에 대해 인원 마감 알림을 생성한다.")
+    @DisplayName("companionClosedNotification: 주최자, 참여자, pending 상태의 신청자, 즐겨찾기 사용자가 받을 인원 마감 알림을 생성한다.")
     @Test
     void createCompanionClosedNotification() {
         // given
@@ -113,12 +112,12 @@ class NotificationServiceTest {
 
         // then
         assertThat(notificationRepository.findAll()).hasSize(4)
-                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle", "travelDueDate")
+                .extracting("receiverNumber", "title", "content", "isRead", "travelHost", "travelNumber", "travelTitle")
                 .containsExactlyInAnyOrder(
-                        tuple(1, "모집 마감 알림", "[여행Title]의 인원이 가득 차 모집이 마감되었어요.", false, true, 10, "여행Title", LocalDate.of(2024, 11, 16)),
-                        tuple(2, "모집 마감 알림", "참가하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)),
-                        tuple(3, "모집 마감 알림", "참가 신청하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16)),
-                        tuple(4, "모집 마감 알림", "즐겨찾기하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title", LocalDate.of(2024, 11, 16))
+                        tuple(1, "모집 마감 알림", "[여행Title]의 인원이 가득 차 모집이 마감되었어요.", false, true, 10, "여행Title"),
+                        tuple(2, "모집 마감 알림", "참가하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title"),
+                        tuple(3, "모집 마감 알림", "참가 신청하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title"),
+                        tuple(4, "모집 마감 알림", "즐겨찾기하신 [여행Title]의 모집이 마감되었어요.", false, false, 10, "여행Title")
                 );
     }
 
@@ -135,7 +134,6 @@ class NotificationServiceTest {
                 .userNumber(hostUserNumber)
                 .title("여행Title")
                 .maxPerson(2)
-                .dueDate(LocalDate.of(2024, 11, 16))
                 .build();
     }
 }

--- a/src/test/java/swyp/swyp6_team7/tag/service/TravelTagServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/tag/service/TravelTagServiceTest.java
@@ -18,6 +18,7 @@ import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -104,6 +105,8 @@ class TravelTagServiceTest {
         return Travel.builder()
                 .userNumber(1)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(0)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelAppliedControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelAppliedControllerTest.java
@@ -20,7 +20,6 @@ import swyp.swyp6_team7.global.utils.auth.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.dto.response.TravelListResponseDto;
 import swyp.swyp6_team7.travel.service.TravelAppliedService;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -57,7 +56,6 @@ public class TravelAppliedControllerTest {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
         LocalDateTime createdAt = LocalDateTime.parse("2024-10-02 21:56", dateTimeFormatter);
-        LocalDate registerDue = LocalDate.parse("2025-05-15", dateFormatter);
 
         TravelListResponseDto responseDto = TravelListResponseDto.builder()
                 .travelNumber(25)
@@ -68,7 +66,6 @@ public class TravelAppliedControllerTest {
                 .nowPerson(1)
                 .maxPerson(5)
                 .createdAt(createdAt)
-                .registerDue(registerDue)
                 .isBookmarked(false)
                 .build();
         Page<TravelListResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), pageable, 1);
@@ -93,7 +90,6 @@ public class TravelAppliedControllerTest {
                     .andExpect(jsonPath("$.success.page.totalElements").value(1))
                     .andExpect(jsonPath("$.success.page.totalPages").value(1));
         }
-
     }
 
     @DisplayName("사용자가 특정 여행에 대한 참가 신청을 취소한다")

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -25,6 +25,7 @@ import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.service.TravelService;
 import swyp.swyp6_team7.travel.service.TravelViewCountService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -64,13 +65,14 @@ class TravelControllerTest {
         // given
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("서울")
+                .startDate(LocalDate.of(2024, 12, 22))
+                .endDate(LocalDate.of(2024, 12, 28))
                 .title("여행 제목")
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
-                .completionStatus(true)
                 .build();
 
         int travelNumber = 10;
@@ -97,13 +99,14 @@ class TravelControllerTest {
         // given
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("서울")
+                .startDate(LocalDate.of(2024, 12, 22))
+                .endDate(LocalDate.of(2024, 12, 28))
                 .title("*".repeat(21))
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
-                .completionStatus(true)
                 .build();
 
         // when
@@ -114,7 +117,6 @@ class TravelControllerTest {
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.reason").value("여행 제목은 최대 20자 입니다."));
-        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
     }
 
     @DisplayName("create: 여행 생성 요청 시 maxPerson의 값이 0보다 작으면 예외가 발생한다.")
@@ -124,13 +126,14 @@ class TravelControllerTest {
         // given
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("서울")
+                .startDate(LocalDate.of(2024, 12, 22))
+                .endDate(LocalDate.of(2024, 12, 28))
                 .title("여행 제목")
                 .details("여행 내용")
                 .maxPerson(-1)
                 .genderType("모두")
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
-                .completionStatus(true)
                 .build();
 
         // when
@@ -141,9 +144,7 @@ class TravelControllerTest {
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.reason").value("여행 참가 최대 인원은 0보다 작을 수 없습니다."));
-        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
     }
-
 
     @DisplayName("getDetailsByNumber: 비회원(비로그인) 사용자는 여행 상세 정보를 단건 조회할 수 있다.")
     @Test
@@ -171,6 +172,8 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.success.profileUrl").value("https://user-profile-url"))
                 .andExpect(jsonPath("$.success.createdAt").value("2024-12-06 12:00"))
                 .andExpect(jsonPath("$.success.location").value("서울"))
+                .andExpect(jsonPath("$.success.startDate").value("2024-11-22"))
+                .andExpect(jsonPath("$.success.endDate").value("2024-11-28"))
                 .andExpect(jsonPath("$.success.title").value("여행 제목"))
                 .andExpect(jsonPath("$.success.details").value("여행 상세 내용"))
                 .andExpect(jsonPath("$.success.viewCount").value(10))
@@ -220,6 +223,8 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.success.profileUrl").value("https://user-profile-url"))
                 .andExpect(jsonPath("$.success.createdAt").value("2024-12-06 12:00"))
                 .andExpect(jsonPath("$.success.location").value("서울"))
+                .andExpect(jsonPath("$.success.startDate").value("2024-11-22"))
+                .andExpect(jsonPath("$.success.endDate").value("2024-11-28"))
                 .andExpect(jsonPath("$.success.title").value("여행 제목"))
                 .andExpect(jsonPath("$.success.details").value("여행 상세 내용"))
                 .andExpect(jsonPath("$.success.viewCount").value(10))
@@ -245,13 +250,14 @@ class TravelControllerTest {
         // given
         TravelUpdateRequest request = TravelUpdateRequest.builder()
                 .locationName("서울")
+                .startDate(LocalDate.of(2024, 12, 22))
+                .endDate(LocalDate.of(2024, 12, 28))
                 .title("여행 제목")
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
-                .completionStatus(true)
                 .build();
 
         int travelNumber = 10;
@@ -287,6 +293,8 @@ class TravelControllerTest {
                 .profileUrl("https://user-profile-url")
                 .createdAt(LocalDateTime.of(2024, 12, 06, 12, 0))
                 .location("서울")
+                .startDate(LocalDate.of(2024,11,22))
+                .endDate(LocalDate.of(2024,11,28))
                 .title("여행 제목")
                 .details("여행 상세 내용")
                 .viewCount(10)

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelControllerTest.java
@@ -25,7 +25,6 @@ import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.service.TravelService;
 import swyp.swyp6_team7.travel.service.TravelViewCountService;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -69,7 +68,6 @@ class TravelControllerTest {
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
-                .dueDate(LocalDate.now().plusDays(10))
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -103,7 +101,6 @@ class TravelControllerTest {
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
-                .dueDate(LocalDate.now().plusDays(10))
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -120,7 +117,7 @@ class TravelControllerTest {
         then(travelService.create(any(TravelCreateRequest.class), eq(2)));
     }
 
-    @DisplayName("create: 여행 생성 요청 시 maxPerson의 값이 0보다 작을 경우 예외가 발생한다.")
+    @DisplayName("create: 여행 생성 요청 시 maxPerson의 값이 0보다 작으면 예외가 발생한다.")
     @WithMockCustomUser(userNumber = 2)
     @Test
     public void createWithValidateMaxPerson() throws Exception {
@@ -131,7 +128,6 @@ class TravelControllerTest {
                 .details("여행 내용")
                 .maxPerson(-1)
                 .genderType("모두")
-                .dueDate(LocalDate.now().plusDays(10))
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -145,40 +141,6 @@ class TravelControllerTest {
         // then
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.reason").value("여행 참가 최대 인원은 0보다 작을 수 없습니다."));
-        then(travelService.create(any(TravelCreateRequest.class), eq(2)));
-    }
-
-    @DisplayName("create: 여행 생성 요청 시 dueDate가 오늘보다 이전인 경우 예외가 발생한다.")
-    @WithMockCustomUser(userNumber = 2)
-    @Test
-    public void createWithValidateDueDate() throws Exception {
-        // given
-        TravelCreateRequest request = TravelCreateRequest.builder()
-                .locationName("서울")
-                .title("여행 제목")
-                .details("여행 내용")
-                .maxPerson(2)
-                .genderType("모두")
-                .dueDate(LocalDate.now().minusDays(10))
-                .periodType("일주일 이하")
-                .tags(List.of("쇼핑"))
-                .completionStatus(true)
-                .build();
-
-        int travelNumber = 10;
-        Travel createdTravel = createTravel(travelNumber, 2);
-
-        given(travelService.create(any(TravelCreateRequest.class), anyInt()))
-                .willReturn(createdTravel);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(post("/api/travel")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(request)));
-
-        // then
-        resultActions.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.reason").value("여행 신청 마감 날짜는 현재 날짜보다 이전일 수 없습니다."));
         then(travelService.create(any(TravelCreateRequest.class), eq(2)));
     }
 
@@ -217,7 +179,6 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.success.nowPerson").value(1))
                 .andExpect(jsonPath("$.success.maxPerson").value(4))
                 .andExpect(jsonPath("$.success.genderType").value("모두"))
-                .andExpect(jsonPath("$.success.dueDate").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.tags[0]").value("자연"))
                 .andExpect(jsonPath("$.success.tags[1]").value("쇼핑"))
                 .andExpect(jsonPath("$.success.postStatus").value("진행중"))
@@ -267,7 +228,6 @@ class TravelControllerTest {
                 .andExpect(jsonPath("$.success.nowPerson").value(1))
                 .andExpect(jsonPath("$.success.maxPerson").value(4))
                 .andExpect(jsonPath("$.success.genderType").value("모두"))
-                .andExpect(jsonPath("$.success.dueDate").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.tags[0]").value("자연"))
                 .andExpect(jsonPath("$.success.tags[1]").value("쇼핑"))
                 .andExpect(jsonPath("$.success.postStatus").value("진행중"))
@@ -278,7 +238,7 @@ class TravelControllerTest {
         then(travelService).should().getTravelDetailMemberRelatedInfo(2, 10, 1, "진행중");
     }
 
-    @DisplayName("update: 사용자는 여행 콘텐츠를 수정할 수 있다.")
+    @DisplayName("update: 사용자는 자신이 작성한 여행 콘텐츠를 수정할 수 있다.")
     @WithMockCustomUser(userNumber = 2)
     @Test
     public void update() throws Exception {
@@ -289,7 +249,6 @@ class TravelControllerTest {
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType("모두")
-                .dueDate(LocalDate.now().plusDays(10))
                 .periodType("일주일 이하")
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -336,7 +295,6 @@ class TravelControllerTest {
                 .nowPerson(1)
                 .maxPerson(4)
                 .genderType(GenderType.MIXED.getDescription())
-                .dueDate(LocalDate.of(2024, 12, 30))
                 .periodType(PeriodType.ONE_WEEK.getDescription())
                 .tags(List.of("자연", "쇼핑"))
                 .postStatus(TravelStatus.IN_PROGRESS.toString())

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelHomeControllerTest.java
@@ -42,7 +42,7 @@ class TravelHomeControllerTest {
     private TravelHomeService travelHomeService;
 
 
-    @DisplayName("getRecentlyCreatedTravels: 최근 생성된 여행 순서로 여행 목록을 조회할 수 있다.")
+    @DisplayName("getRecentlyCreatedTravels: 최근 생성된 순서로 정렬된 여행 목록을 조회할 수 있다.")
     @WithMockCustomUser(userNumber = 2)
     @Test
     void getRecentlyCreatedTravels() throws Exception {
@@ -72,7 +72,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[0].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[0].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[0].createdAt").value("2024-12-06 12:00"))
-                .andExpect(jsonPath("$.success.content[0].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[0].bookmarked").value(false))
                 .andExpect(jsonPath("$.success.content[1].travelNumber").value(10))
                 .andExpect(jsonPath("$.success.content[1].userNumber").value(1))
@@ -80,7 +79,7 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[1].bookmarked").value(true));
     }
 
-    @DisplayName("getRecentlyCreatedTravels: 비로그인 사용자도 최근 생성된 여행 순서로 여행 목록을 조회할 수 있다.")
+    @DisplayName("getRecentlyCreatedTravels: 비로그인 사용자는 최근 생성된 순서로 정렬된 여행 목록을 조회할 수 있다.")
     @Test
     void getRecentlyCreatedTravelsWhenNotLogin() throws Exception {
         // given
@@ -110,7 +109,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[0].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[0].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[0].createdAt").value("2024-12-06 12:00"))
-                .andExpect(jsonPath("$.success.content[0].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[0].bookmarked").value(false))
                 .andExpect(jsonPath("$.success.content[1].travelNumber").value(10))
                 .andExpect(jsonPath("$.success.content[1].userNumber").value(1))
@@ -150,7 +148,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[0].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[0].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[0].createdAt").value("2024-12-05 12:00"))
-                .andExpect(jsonPath("$.success.content[0].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[0].bookmarked").value(true))
                 .andExpect(jsonPath("$.success.content[1].travelNumber").value(10))
                 .andExpect(jsonPath("$.success.content[1].title").value("여행 제목"))
@@ -161,7 +158,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[1].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[1].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[1].createdAt").value("2024-12-05 12:00"))
-                .andExpect(jsonPath("$.success.content[1].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[1].bookmarked").value(false));
     }
 
@@ -195,7 +191,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[0].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[0].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[0].createdAt").value("2024-12-05 12:00"))
-                .andExpect(jsonPath("$.success.content[0].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[0].bookmarked").value(false))
                 .andExpect(jsonPath("$.success.content[1].travelNumber").value(10))
                 .andExpect(jsonPath("$.success.content[1].title").value("여행 제목"))
@@ -206,7 +201,6 @@ class TravelHomeControllerTest {
                 .andExpect(jsonPath("$.success.content[1].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[1].maxPerson").value(3))
                 .andExpect(jsonPath("$.success.content[1].createdAt").value("2024-12-05 12:00"))
-                .andExpect(jsonPath("$.success.content[1].registerDue").value("2024-12-30"))
                 .andExpect(jsonPath("$.success.content[1].bookmarked").value(false));
     }
 
@@ -221,7 +215,6 @@ class TravelHomeControllerTest {
                 .nowPerson(1)
                 .maxPerson(3)
                 .createdAt(createdAt)
-                .registerDue(LocalDate.of(2024, 12, 30))
                 .isBookmarked(bookmarked)
                 .build();
     }
@@ -237,7 +230,6 @@ class TravelHomeControllerTest {
                 .nowPerson(1)
                 .maxPerson(3)
                 .createdAt(LocalDateTime.of(2024, 12, 5, 12, 0))
-                .registerDue(LocalDate.of(2024, 12, 30))
                 .preferredNumber(preferredNumber)
                 .isBookmarked(bookmarked)
                 .build();
@@ -254,7 +246,6 @@ class TravelHomeControllerTest {
                 .nowPerson(1)
                 .maxPerson(3)
                 .createdAt(LocalDateTime.of(2024, 12, 5, 12, 0))
-                .registerDue(LocalDate.of(2024, 12, 30))
                 .build();
     }
 }

--- a/src/test/java/swyp/swyp6_team7/travel/controller/TravelListControllerTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/controller/TravelListControllerTest.java
@@ -18,7 +18,6 @@ import swyp.swyp6_team7.global.utils.auth.MemberAuthorizeUtil;
 import swyp.swyp6_team7.travel.dto.response.TravelListResponseDto;
 import swyp.swyp6_team7.travel.service.TravelListService;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -58,9 +57,7 @@ public class TravelListControllerTest {
         //Integer userNumber = 1;
         Pageable pageable = PageRequest.of(0, 5);
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDateTime createdAt = LocalDateTime.parse("2024-10-02 21:56", dateTimeFormatter);
-        LocalDate registerDue = LocalDate.parse("2025-05-15", dateFormatter);
         TravelListResponseDto responseDto = TravelListResponseDto.builder()
                 .travelNumber(25)
                 .title("호주 여행 같이 갈 사람 구해요")
@@ -70,7 +67,6 @@ public class TravelListControllerTest {
                 .nowPerson(1)
                 .maxPerson(5)
                 .createdAt(createdAt)
-                .registerDue(registerDue)
                 .isBookmarked(true)
                 .build();
         Page<TravelListResponseDto> page = new PageImpl<>(Collections.singletonList(responseDto), pageable, 1);
@@ -95,7 +91,6 @@ public class TravelListControllerTest {
                 .andExpect(jsonPath("$.success.content[0].nowPerson").value(1))
                 .andExpect(jsonPath("$.success.content[0].maxPerson").value(5))
                 .andExpect(jsonPath("$.success.content[0].createdAt").value("2024-10-02 21:56"))
-                .andExpect(jsonPath("$.success.content[0].registerDue").value("2025-05-15"))
                 //.andExpect(jsonPath("$.content[0].isBookmarked").value(true))
                 .andExpect(jsonPath("$.success.page.size").value(5))
                 .andExpect(jsonPath("$.success.page.number").value(0))

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -60,7 +60,7 @@ class TravelCustomRepositoryImplTest {
     private BookmarkRepository bookmarkRepository;
 
 
-    @DisplayName("getDetailsByNumber: 여행 번호가 주어지면 여행의 디테일 정보를 가져올 수 있다.")
+    @DisplayName("getDetailsByNumber: 여행 번호가 주어지면 여행의 상세 정보를 가져올 수 있다.")
     @Test
     public void getDetailsByNumber() {
         // given
@@ -71,10 +71,9 @@ class TravelCustomRepositoryImplTest {
         List<Tag> tags = tagRepository.saveAll(Arrays.asList(tag1, tag2));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 host.getUserNumber(), location, "여행", 0, 2, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, tags);
+                PeriodType.ONE_WEEK, IN_PROGRESS, tags);
         travelRepository.save(travel1);
 
         // when
@@ -86,23 +85,21 @@ class TravelCustomRepositoryImplTest {
                 .contains(travel1, host.getUserNumber(), "주최자 이름", "10대", 0, List.of("쇼핑", "자연"));
     }
 
-    @DisplayName("findAll: 여행을 최신순으로 가져올 수 있다.")
+    @DisplayName("findAll: 생성 날짜가 최신 순서로 정렬된 여행 목록을 조회할 수 있다.")
     @Test
     public void findAllSortedByCreatedAt() {
         // given
         Users host = userRepository.save(createHostUser());
-
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
 
         Travel travel1 = createTravel(
                 host.getUserNumber(), location, "여행", 0, 2, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.save(travel1);
 
         Travel travel2 = createTravel(
                 host.getUserNumber(), location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.save(travel2);
 
         // when
@@ -111,14 +108,14 @@ class TravelCustomRepositoryImplTest {
 
         // then
         assertThat(results.getContent()).hasSize(2)
-                .extracting("travelNumber", "title", "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue")
+                .extracting("travelNumber", "title", "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson")
                 .containsExactly(
-                        tuple(travel2.getNumber(), "여행", "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate),
-                        tuple(travel1.getNumber(), "여행", "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 2, dueDate)
+                        tuple(travel2.getNumber(), "여행", "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0),
+                        tuple(travel1.getNumber(), "여행", "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 2)
                 );
     }
 
-    @DisplayName("findAllByPreferredTags: 사용자의 선호 태그와 콘텐츠 태그의 중복 태그 개수를 여행과 함께 가져올 수 있다.")
+    @DisplayName("findAllByPreferredTags: 사용자의 선호 태그가 많이 포함된 순서로 정렬된 여행 목록과 포함된 태그 개수를 함께 가져온다.")
     @Test
     public void findAllByPreferredTags() {
         // given
@@ -129,19 +126,18 @@ class TravelCustomRepositoryImplTest {
         tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
         Travel travel4 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
         travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
 
         List<String> preferredTags = Arrays.asList("쇼핑", "자연", "먹방");
@@ -162,6 +158,7 @@ class TravelCustomRepositoryImplTest {
                 );
     }
 
+    /*
     @DisplayName("findAllByPreferredTags: 주어지는 날짜보다 마감일이 늦은 여행만 가져온다.")
     @Test
     public void findAllByPreferredTagsWithDate() {
@@ -204,21 +201,20 @@ class TravelCustomRepositoryImplTest {
                         tuple(travel3.getNumber(), Arrays.asList("쇼핑", "즉흥"), 1),
                         tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3)
                 );
-    }
+    }*/
 
-    @DisplayName("findAllByBookmarkNumberAndTitle: 북마크 개수가 많은 순서로 여행을 가져온다.")
+    @DisplayName("findAllByBookmarkNumberAndTitle: 북마크 개수가 많은 순서로 정렬된 여행 목록을 가져온다.")
     @Test
     void findAllByBookmarkNumberAndTitle() {
         // given
         Users host = userRepository.save(createHostUser());
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 9);
         Travel travel1 = createTravel(
                 host.getUserNumber(), location, "여행1", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 host.getUserNumber(), location, "여행2", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         LocalDateTime createdAt = LocalDateTime.of(2024, 12, 7, 12, 0);
@@ -230,33 +226,32 @@ class TravelCustomRepositoryImplTest {
         LocalDate requestDate = LocalDate.of(2024, 11, 8);
 
         // when
-        Page<TravelRecommendForNonMemberDto> result = travelRepository.findAllSortedByBookmarkNumberAndTitle(PageRequest.of(0, 5),  requestDate);
+        Page<TravelRecommendForNonMemberDto> result = travelRepository.findAllSortedByBookmarkNumberAndTitle(PageRequest.of(0, 5), requestDate);
 
         // then
         assertThat(result.getContent()).hasSize(2)
                 .extracting("travelNumber", "title", "bookmarkCount",
-                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue")
+                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson")
                 .containsExactly(
                         tuple(travel2.getNumber(), "여행2", 2,
-                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate),
+                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0),
                         tuple(travel1.getNumber(), "여행1", 1,
-                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate)
+                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0)
                 );
     }
 
-    @DisplayName("findAllByBookmarkNumberAndTitle: 북마크 개수가 같다면 제목 사전순 정렬으로 가져온다.")
+    @DisplayName("findAllByBookmarkNumberAndTitle: 북마크 개수가 같으면 제목 사전순으로 추가 정렬한다.")
     @Test
     void findAllByBookmarkNumberAndTitleWhenSameBookmarkNumber() {
         // given
         Users host = userRepository.save(createHostUser());
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 9);
         Travel travel1 = createTravel(
                 host.getUserNumber(), location, "여행갸", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 host.getUserNumber(), location, "여행가", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         LocalDateTime createdAt = LocalDateTime.of(2024, 12, 7, 12, 0);
@@ -272,15 +267,16 @@ class TravelCustomRepositoryImplTest {
         // then
         assertThat(result.getContent()).hasSize(2)
                 .extracting("travelNumber", "title", "bookmarkCount",
-                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue")
+                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson")
                 .containsExactly(
                         tuple(travel2.getNumber(), "여행가", 1,
-                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate),
+                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0),
                         tuple(travel1.getNumber(), "여행갸", 1,
-                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate)
+                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0)
                 );
     }
 
+    /*
     @DisplayName("findAllByBookmarkNumberAndTitle: 주어지는 날짜보다 마감일이 늦은 여행만 가져온다.")
     @Test
     void findAllByBookmarkNumberAndTitleWithDate() {
@@ -308,7 +304,7 @@ class TravelCustomRepositoryImplTest {
         LocalDate requestDate = LocalDate.of(2024, 11, 8);
 
         // when
-        Page<TravelRecommendForNonMemberDto> result = travelRepository.findAllSortedByBookmarkNumberAndTitle(PageRequest.of(0, 5),  requestDate);
+        Page<TravelRecommendForNonMemberDto> result = travelRepository.findAllSortedByBookmarkNumberAndTitle(PageRequest.of(0, 5), requestDate);
 
         // then
         assertThat(result.getContent()).hasSize(1)
@@ -318,20 +314,19 @@ class TravelCustomRepositoryImplTest {
                         tuple(travel2.getNumber(), "여행2", 2,
                                 "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate2)
                 );
-    }
+    }*/
 
-    @DisplayName("search: keyword가 포함된 여행을 가져올 수 있다.")
+    @DisplayName("search: 제목에 keyword가 포함된 여행 목록을 가져올 수 있다.")
     @Test
     public void searchWithKeyword() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "Seoul 여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "키워드", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -348,19 +343,18 @@ class TravelCustomRepositoryImplTest {
                 .allMatch(title -> ((String) title).contains("키워드"));
     }
 
-    @DisplayName("search: 장소 이름에 keyword가 포함된 여행을 가져올 수 있다.")
+    @DisplayName("search: 장소 이름에 keyword가 포함된 여행 목록을 가져올 수 있다.")
     @Test
     public void searchWithKeywordThroughTitleAndLocation() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
         Location location2 = locationRepository.save(createLocation("Busan", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행1", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location2, "여행2", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -383,13 +377,12 @@ class TravelCustomRepositoryImplTest {
     public void searchWithoutKeyword() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "Seoul 여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "키워드", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -403,21 +396,20 @@ class TravelCustomRepositoryImplTest {
         assertThat(results.getContent()).hasSize(2);
     }
 
-    @DisplayName("search: 콘텐츠의 상태가 IN_PROGRESS, CLOSED인 여행만 가져온다.")
+    @DisplayName("search: 콘텐츠의 상태가 IN_PROGRESS, CLOSED인 여행만 검색 결과에 포함되어 있다.")
     @Test
     public void searchOnlyActivated() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, DELETED, new ArrayList<>());
+                PeriodType.ONE_WEEK, DELETED, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, CLOSED, new ArrayList<>());
+                PeriodType.ONE_WEEK, CLOSED, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -433,7 +425,7 @@ class TravelCustomRepositoryImplTest {
                 .allMatch(status -> List.of(IN_PROGRESS.toString(), CLOSED.toString()).contains(status));
     }
 
-    @DisplayName("search: 여러 개의 문자열이 주어질 때, 해당 문자열의 태그를 전부 포함하는 여행을 가져온다.")
+    @DisplayName("search: 여러 개의 태그 이름이 주어질 때, 태그를 전부 포함하는 여행 목록을 가져온다.")
     @Test
     public void searchWithTags() {
         // given
@@ -442,13 +434,12 @@ class TravelCustomRepositoryImplTest {
         tagRepository.saveAll(Arrays.asList(tag1, tag2));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
         travelRepository.saveAll(List.of(travel1, travel2));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -466,21 +457,20 @@ class TravelCustomRepositoryImplTest {
                 );
     }
 
-    @DisplayName("search: 주어지는 GenderType에 해당하는 여행을 가져올 수 있다.")
+    @DisplayName("search: 주어지는 GenderType을 가진 여행 목록을 가져올 수 있다.")
     @Test
     public void searchWithGenderFilter() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.WOMAN_ONLY,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MAN_ONLY,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -497,21 +487,20 @@ class TravelCustomRepositoryImplTest {
                 .containsExactlyInAnyOrder(travel1.getNumber(), travel2.getNumber());
     }
 
-    @DisplayName("search: 주어지는 PeriodType에 해당하는 여행을 가져올 수 있다.")
+    @DisplayName("search: 주어지는 PeriodType을 가진 여행 목록을 가져올 수 있다.")
     @Test
     public void searchWithPeriodFilter() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
+                PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
+                PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+                PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -529,24 +518,23 @@ class TravelCustomRepositoryImplTest {
     }
 
 
-    @DisplayName("search: 주어지는 personTypes에 해당하는 여행을 가져올 수 있다.")
+    @DisplayName("search: 주어지는 personTypes을 가진 여행을 가져올 수 있다.")
     @Test
     public void searchWithPersonRangeFilter() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 2, GenderType.MIXED,
-                dueDate, PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
+                PeriodType.MORE_THAN_MONTH, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 3, GenderType.MIXED,
-                dueDate, PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
+                PeriodType.THREE_WEEKS, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 4, GenderType.MIXED,
-                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+                PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
         Travel travel4 = createTravel(
                 1, location, "여행", 0, 5, GenderType.MIXED,
-                dueDate, PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
+                PeriodType.TWO_WEEKS, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -564,7 +552,7 @@ class TravelCustomRepositoryImplTest {
     }
 
 
-    @DisplayName("search: 장소 필터링을 통해 국내 카테고리의 여행을 검색할 수 있다.")
+    @DisplayName("search: 국내 카테고리(DOMESTIC)에 해당하는 여행을 검색할 수 있다.")
     @Test
     public void searchDomesticTravelWithLocationFilter() {
         // given
@@ -574,13 +562,13 @@ class TravelCustomRepositoryImplTest {
         LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -597,23 +585,22 @@ class TravelCustomRepositoryImplTest {
                 .containsExactlyInAnyOrder(travel1.getNumber(), travel2.getNumber());
     }
 
-    @DisplayName("search: 장소 필터링을 통해 해외 카테고리의 여행을 검색할 수 있다.")
+    @DisplayName("search: 해외 카테고리(INTERNATIONAL)에 해당하는 여행을 검색할 수 있다.")
     @Test
     public void searchInternationalTravelWithLocationFilter() {
         // given
         Location domesticLocation = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
         Location internationalLocation = locationRepository.save(createLocation("London", LocationType.INTERNATIONAL));
 
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, domesticLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, internationalLocation, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -630,21 +617,20 @@ class TravelCustomRepositoryImplTest {
                 .containsExactlyInAnyOrder(travel2.getNumber(), travel3.getNumber());
     }
 
-    @DisplayName("search: 검색할 때 정렬 키워드가 주어지지 않으면, dueDate가 빠른 순서대로 정렬된다.")
+    @DisplayName("search: 검색 정렬 조건이 주어지지 않으면, 최신 생성 순서로 정렬된 여행 목록을 가져온다.")
     @Test
     public void searchWithoutSortingType() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(2), PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
@@ -660,50 +646,20 @@ class TravelCustomRepositoryImplTest {
                 .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
     }
 
-    @DisplayName("search: 검색할 때 정렬 키워드가 주어지지 않았을 때, dueDate가 동일하면 최근 생성된 순서로 정렬된다.")
-    @Test
-    public void searchWithoutSortingType2() {
-        // given
-        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
-        Travel travel1 = travelRepository.save(createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
-        Travel travel2 = travelRepository.save(createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
-        Travel travel3 = travelRepository.save(createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>()));
-
-        TravelSearchCondition condition = TravelSearchCondition.builder()
-                .pageRequest(PageRequest.of(0, 5))
-                .build();
-
-        // when
-        Page<TravelSearchDto> results = travelRepository.search(condition);
-
-        // then
-        assertThat(results.getContent()).hasSize(3)
-                .extracting("travelNumber")
-                .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
-    }
-
-    @DisplayName("search: 추천순 정렬은 북마크 개수, 조회수가 많은 순서대로 여행을 가져온다.")
+    @DisplayName("search: 검색의 추천순 정렬은 북마크 개수, 조회수가 많은 순서대로 정렬된 여행 목록을 가져온다.")
     @Test
     public void searchWithRecommendSorting() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 3, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 2, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         LocalDateTime createdAt = LocalDateTime.of(2024, 11, 6, 12, 0);
@@ -726,21 +682,20 @@ class TravelCustomRepositoryImplTest {
                 .containsExactly(travel3.getNumber(), travel2.getNumber(), travel1.getNumber());
     }
 
-    @DisplayName("search: 추천순 정렬에서 북마크가 동일한 경우 조회수가 많은 순서대로 여행을 가져온다.")
+    @DisplayName("search: 검색 추천순 정렬에서 북마크 개수가 동일하면, 조회수가 많은 순서대로 추가 정렬한다.")
     @Test
     void searchWithRecommendSorting2() {
         // given
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel2 = createTravel(
                 1, location, "여행", 3, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         Travel travel3 = createTravel(
                 1, location, "여행", 1, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+                PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         LocalDateTime createdAt = LocalDateTime.of(2024, 11, 6, 12, 0);
@@ -784,8 +739,8 @@ class TravelCustomRepositoryImplTest {
     }
 
     private Travel createTravel(
-            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
-            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+            int hostNumber, Location location, String title, int viewCount, int maxPerson,
+            GenderType genderType, PeriodType periodType, TravelStatus status, List<Tag> tags
     ) {
         return Travel.builder()
                 .userNumber(hostNumber)
@@ -796,7 +751,6 @@ class TravelCustomRepositoryImplTest {
                 .viewCount(viewCount)
                 .maxPerson(maxPerson)
                 .genderType(genderType)
-                .dueDate(dueDate)
                 .periodType(periodType)
                 .status(status)
                 .tags(tags)

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelCustomRepositoryImplTest.java
@@ -158,8 +158,7 @@ class TravelCustomRepositoryImplTest {
                 );
     }
 
-    /*
-    @DisplayName("findAllByPreferredTags: 주어지는 날짜보다 마감일이 늦은 여행만 가져온다.")
+    @DisplayName("findAllByPreferredTags: 여행 시작 날짜가 지난 여행은 목록에 포함시키지 않는다.")
     @Test
     public void findAllByPreferredTagsWithDate() {
         // given
@@ -170,25 +169,27 @@ class TravelCustomRepositoryImplTest {
         tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate1 = LocalDate.of(2024, 11, 7);
-        Travel travel1 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate1, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
-        Travel travel2 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate1, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
 
-        LocalDate dueDate2 = LocalDate.of(2024, 11, 9);
-        Travel travel3 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate2, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
-        Travel travel4 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate2, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
+        LocalDate startDate1 = LocalDate.of(2024, 11, 22);
+        LocalDate endDate = LocalDate.of(2024, 11, 28);
+        Travel travel1 = createTravelWithDate(
+                1, location, startDate1, endDate, "여행", 0, 0,
+                GenderType.MIXED, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+        Travel travel2 = createTravelWithDate(
+                1, location, startDate1, endDate, "여행", 0, 0, GenderType.MIXED,
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+
+        LocalDate startDate2 = LocalDate.of(2024, 11, 25);
+        Travel travel3 = createTravelWithDate(
+                1, location, startDate2, endDate, "여행", 0, 0,
+                GenderType.MIXED, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
+        Travel travel4 = createTravelWithDate(
+                1, location, startDate2, endDate, "여행", 0, 0,
+                GenderType.MIXED, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
         travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
 
         List<String> preferredTags = Arrays.asList("쇼핑", "자연", "먹방");
-        LocalDate requestDate = LocalDate.of(2024, 11, 8);
+        LocalDate requestDate = LocalDate.of(2024, 11, 24);
 
         // when
         Page<TravelRecommendForMemberDto> result = travelRepository
@@ -201,7 +202,7 @@ class TravelCustomRepositoryImplTest {
                         tuple(travel3.getNumber(), Arrays.asList("쇼핑", "즉흥"), 1),
                         tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3)
                 );
-    }*/
+    }
 
     @DisplayName("findAllByBookmarkNumberAndTitle: 북마크 개수가 많은 순서로 정렬된 여행 목록을 가져온다.")
     @Test
@@ -276,23 +277,23 @@ class TravelCustomRepositoryImplTest {
                 );
     }
 
-    /*
-    @DisplayName("findAllByBookmarkNumberAndTitle: 주어지는 날짜보다 마감일이 늦은 여행만 가져온다.")
+    @DisplayName("findAllByBookmarkNumberAndTitle: 여행 시작 날짜가 지난 여행은 목록에 포함시키지 않는다.")
     @Test
     void findAllByBookmarkNumberAndTitleWithDate() {
         // given
         Users host = userRepository.save(createHostUser());
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
 
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
-        Travel travel1 = createTravel(
-                host.getUserNumber(), location, "여행1", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        LocalDate startDate1 = LocalDate.of(2024, 11, 22);
+        LocalDate endDate = LocalDate.of(2024, 11, 28);
+        Travel travel1 = createTravelWithDate(
+                host.getUserNumber(), location, startDate1, endDate, "여행1", 0, 0,
+                GenderType.MIXED, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
 
-        LocalDate dueDate2 = LocalDate.of(2024, 11, 9);
-        Travel travel2 = createTravel(
-                host.getUserNumber(), location, "여행2", 0, 0, GenderType.MIXED,
-                dueDate2, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
+        LocalDate startDate2 = LocalDate.of(2024, 11, 25);
+        Travel travel2 = createTravelWithDate(
+                host.getUserNumber(), location, startDate2, endDate, "여행2", 0, 0,
+                GenderType.MIXED, PeriodType.ONE_WEEK, IN_PROGRESS, new ArrayList<>());
         travelRepository.saveAll(List.of(travel1, travel2));
 
         LocalDateTime createdAt = LocalDateTime.of(2024, 12, 7, 12, 0);
@@ -301,7 +302,7 @@ class TravelCustomRepositoryImplTest {
         Bookmark bookmark3 = createBookmark(travel2.getNumber(), createdAt);
         bookmarkRepository.saveAll(List.of(bookmark1, bookmark2, bookmark3));
 
-        LocalDate requestDate = LocalDate.of(2024, 11, 8);
+        LocalDate requestDate = LocalDate.of(2024, 11, 24);
 
         // when
         Page<TravelRecommendForNonMemberDto> result = travelRepository.findAllSortedByBookmarkNumberAndTitle(PageRequest.of(0, 5), requestDate);
@@ -309,12 +310,12 @@ class TravelCustomRepositoryImplTest {
         // then
         assertThat(result.getContent()).hasSize(1)
                 .extracting("travelNumber", "title", "bookmarkCount",
-                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson", "registerDue")
+                        "location", "userNumber", "userName", "tags", "nowPerson", "maxPerson")
                 .containsExactly(
                         tuple(travel2.getNumber(), "여행2", 2,
-                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0, dueDate2)
+                                "Seoul", host.getUserNumber(), "주최자 이름", List.of(), 0, 0)
                 );
-    }*/
+    }
 
     @DisplayName("search: 제목에 keyword가 포함된 여행 목록을 가져올 수 있다.")
     @Test
@@ -746,6 +747,29 @@ class TravelCustomRepositoryImplTest {
                 .userNumber(hostNumber)
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
+                .title(title)
+                .details("여행 내용")
+                .viewCount(viewCount)
+                .maxPerson(maxPerson)
+                .genderType(genderType)
+                .periodType(periodType)
+                .status(status)
+                .tags(tags)
+                .build();
+    }
+
+    private Travel createTravelWithDate(
+            int hostNumber, Location location, LocalDate startDate, LocalDate endDate, String title, int viewCount,
+            int maxPerson, GenderType genderType, PeriodType periodType, TravelStatus status, List<Tag> tags
+    ) {
+        return Travel.builder()
+                .userNumber(hostNumber)
+                .location(location)
+                .locationName(location.getLocationName())
+                .startDate(startDate)
+                .endDate(endDate)
                 .title(title)
                 .details("여행 내용")
                 .viewCount(viewCount)

--- a/src/test/java/swyp/swyp6_team7/travel/repository/TravelRepositoryTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/repository/TravelRepositoryTest.java
@@ -14,6 +14,7 @@ import swyp.swyp6_team7.travel.domain.PeriodType;
 import swyp.swyp6_team7.travel.domain.Travel;
 import swyp.swyp6_team7.travel.domain.TravelStatus;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +73,8 @@ class TravelRepositoryTest {
         return Travel.builder()
                 .userNumber(1)
                 .location(location)
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .viewCount(nowViewCount)
                 .genderType(GenderType.MIXED)
                 .periodType(PeriodType.ONE_WEEK)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelAppliedServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelAppliedServiceTest.java
@@ -3,12 +3,10 @@ package swyp.swyp6_team7.travel.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import swyp.swyp6_team7.bookmark.repository.BookmarkRepository;
@@ -25,14 +23,13 @@ import swyp.swyp6_team7.travel.domain.TravelStatus;
 import swyp.swyp6_team7.travel.dto.response.TravelListResponseDto;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class TravelAppliedServiceTest {
@@ -68,7 +65,6 @@ public class TravelAppliedServiceTest {
                 .viewCount(100)
                 .maxPerson(5)
                 .genderType(GenderType.MIXED)
-                .dueDate(LocalDate.now().plusDays(10))
                 .periodType(PeriodType.THREE_WEEKS)
                 .status(TravelStatus.IN_PROGRESS)
                 .createdAt(LocalDateTime.now())
@@ -83,7 +79,6 @@ public class TravelAppliedServiceTest {
                 .viewCount(150)
                 .maxPerson(10)
                 .genderType(GenderType.MAN_ONLY)
-                .dueDate(LocalDate.now().plusDays(15))
                 .periodType(PeriodType.THREE_WEEKS)
                 .status(TravelStatus.IN_PROGRESS)
                 .createdAt(LocalDateTime.now())

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
@@ -167,42 +167,7 @@ class TravelHomeServiceTest {
                 );
     }
 
-    /*
-    @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 동일한 경우 registerDue가 빠른 순서대로 여행을 가져온다.")
-    @Test
-    void getRecommendTravelsByMemberWhenSamePreferredNumber() {
-        Tag tag1 = Tag.of("쇼핑");
-        Tag tag2 = Tag.of("자연");
-        tagRepository.saveAll(List.of(tag1, tag2));
-
-        Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
-        Travel travel1 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
-        Travel travel2 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
-        travelRepository.saveAll(List.of(travel1, travel2));
-
-        LocalDate requestDate = LocalDate.of(2024, 11, 6);
-
-        given(userTagPreferenceRepository.findPreferenceTagsByUserNumber(any(Integer.class)))
-                .willReturn(Arrays.asList("쇼핑", "자연"));
-
-        // when
-        Page<TravelRecommendForMemberDto> result = travelHomeService.getRecommendTravelsByMember(PageRequest.of(0, 5), 1, requestDate);
-
-        // then
-        assertThat(result.getContent()).hasSize(2)
-                .extracting("travelNumber", "tags", "preferredNumber", "registerDue")
-                .containsExactly(
-                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate),
-                        tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate.plusDays(1))
-                );
-    }
-
-    @DisplayName("preferredNumber, registerDue가 동일한 경우 title을 기준으로 가나다 순서대로 가져온다.")
+    @DisplayName("preferredNumber 값이 같으면 title이 오름차순으로 정렬된 여행 목록을 가져온다.")
     @Test
     void getRecommendTravelsByMemberWhenSamePreferredNumberSameRegisterDue() {
         Tag tag1 = Tag.of("쇼핑");
@@ -233,7 +198,7 @@ class TravelHomeServiceTest {
                         tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, "여행-가"),
                         tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, "여행-나")
                 );
-    }*/
+    }
 
     private Location createLocation(String locationName, LocationType locationType) {
         return Location.builder()
@@ -250,6 +215,8 @@ class TravelHomeServiceTest {
                 .userNumber(hostNumber)
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .title(title)
                 .details("여행 내용")
                 .viewCount(viewCount)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelHomeServiceTest.java
@@ -70,19 +70,18 @@ class TravelHomeServiceTest {
         locationRepository.deleteAllInBatch();
     }
 
-    @DisplayName("최근 생성된 순서로 여행 목록을 가져오고 로그인 상태인 경우 사용자의 북마크 여부를 추가로 설정한다.")
+    @DisplayName("최근 생성된 순서로 정렬된 여행 목록을 가져오고 로그인 상태라면 사용자의 북마크 여부를 추가로 설정한다.")
     @Test
     void getTravelsSortedByCreatedAt() {
         // given
         Integer loginUserNumber = 1;
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = travelRepository.save(createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
         Travel travel2 = travelRepository.save(createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
 
         Map<Integer, Boolean> bookmarkedMap = new HashMap<>();
         bookmarkedMap.put(travel1.getNumber(), true);
@@ -103,19 +102,18 @@ class TravelHomeServiceTest {
                 );
     }
 
-    @DisplayName("최근 생성된 순서로 여행 목록을 가져오고 비로그인 상태인 경우 사용자의 북마크 여부는 전부 false이다.")
+    @DisplayName("최근 생성된 순서로 여행 목록을 가져오고 비로그인 상태라면 사용자의 북마크 여부는 전부 false이다.")
     @Test
     void getTravelsSortedByCreatedAtWhenNotLogin() {
         // given
         Integer loginUserNumber = null;
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = travelRepository.save(createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
         Travel travel2 = travelRepository.save(createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
 
         // when
         Page<TravelRecentDto> result = travelHomeService.getTravelsSortedByCreatedAt(PageRequest.of(0, 5), loginUserNumber);
@@ -129,7 +127,7 @@ class TravelHomeServiceTest {
                 );
     }
 
-    @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 큰 순서대로 여행 목록을 가져온다.")
+    @DisplayName("사용자의 선호 태그를 많이 가진 순서로 정렬된 여행 목록을 가져온다.")
     @Test
     void getRecommendTravelsByMember() {
         // given
@@ -140,20 +138,16 @@ class TravelHomeServiceTest {
         tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1));
         Travel travel2 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
         Travel travel3 = createTravel(
                 1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag4));
-        Travel travel4 = createTravel(
-                1, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
-        travelRepository.saveAll(List.of(travel1, travel2, travel3, travel4));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2, tag3));
+        travelRepository.saveAll(List.of(travel1, travel2, travel3));
 
         LocalDate requestDate = LocalDate.of(2024, 11, 6);
 
@@ -164,16 +158,16 @@ class TravelHomeServiceTest {
         Page<TravelRecommendForMemberDto> result = travelHomeService.getRecommendTravelsByMember(PageRequest.of(0, 5), 1, requestDate);
 
         // then
-        assertThat(result.getContent()).hasSize(4)
-                .extracting("travelNumber", "tags", "preferredNumber", "registerDue")
+        assertThat(result.getContent()).hasSize(3)
+                .extracting("travelNumber", "tags", "preferredNumber")
                 .containsExactly(
-                        tuple(travel4.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3, dueDate),
-                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate),
-                        tuple(travel1.getNumber(), Arrays.asList("쇼핑"), 1, dueDate),
-                        tuple(travel3.getNumber(), Arrays.asList("쇼핑", "즉흥"), 1, dueDate.plusDays(1))
+                        tuple(travel3.getNumber(), Arrays.asList("쇼핑", "자연", "먹방"), 3),
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2),
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑"), 1)
                 );
     }
 
+    /*
     @DisplayName("사용자의 선호 태그와 공통되는 여행 태그 개수 preferredNumber가 동일한 경우 registerDue가 빠른 순서대로 여행을 가져온다.")
     @Test
     void getRecommendTravelsByMemberWhenSamePreferredNumber() {
@@ -216,13 +210,12 @@ class TravelHomeServiceTest {
         tagRepository.saveAll(List.of(tag1, tag2));
 
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = createTravel(
                 1, location, "여행-나", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
         Travel travel2 = createTravel(
                 1, location, "여행-가", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList(tag1, tag2));
         travelRepository.saveAll(List.of(travel1, travel2));
 
         LocalDate requestDate = LocalDate.of(2024, 11, 6);
@@ -235,12 +228,12 @@ class TravelHomeServiceTest {
 
         // then
         assertThat(result.getContent()).hasSize(2)
-                .extracting("travelNumber", "tags", "preferredNumber", "registerDue", "title")
+                .extracting("travelNumber", "tags", "preferredNumber", "title")
                 .containsExactly(
-                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate, "여행-가"),
-                        tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, dueDate, "여행-나")
+                        tuple(travel2.getNumber(), Arrays.asList("쇼핑", "자연"), 2, "여행-가"),
+                        tuple(travel1.getNumber(), Arrays.asList("쇼핑", "자연"), 2, "여행-나")
                 );
-    }
+    }*/
 
     private Location createLocation(String locationName, LocationType locationType) {
         return Location.builder()
@@ -250,8 +243,8 @@ class TravelHomeServiceTest {
     }
 
     private Travel createTravel(
-            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
-            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+            int hostNumber, Location location, String title, int viewCount, int maxPerson,
+            GenderType genderType, PeriodType periodType, TravelStatus status, List<Tag> tags
     ) {
         return Travel.builder()
                 .userNumber(hostNumber)
@@ -262,11 +255,9 @@ class TravelHomeServiceTest {
                 .viewCount(viewCount)
                 .maxPerson(maxPerson)
                 .genderType(genderType)
-                .dueDate(dueDate)
                 .periodType(periodType)
                 .status(status)
                 .tags(tags)
                 .build();
     }
-
 }

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelListServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelListServiceTest.java
@@ -67,7 +67,6 @@ class TravelListServiceTest {
                 .createdAt(LocalDateTime.now().minusDays(2))
                 .title("Title 1")
                 .maxPerson(5)
-                .dueDate(LocalDate.now().plusDays(3))
                 .location(travelLocation)
                 .build();
 
@@ -77,7 +76,6 @@ class TravelListServiceTest {
                 .createdAt(LocalDateTime.now().minusDays(6))
                 .title("Title 2")
                 .maxPerson(10)
-                .dueDate(LocalDate.now().minusDays(1))
                 .location(travelLocation)
                 .build();
 
@@ -112,7 +110,6 @@ class TravelListServiceTest {
                     travel.getCompanions().size(),
                     travel.getMaxPerson(),
                     travel.getCreatedAt(),
-                    travel.getDueDate(),
                     isBookmarked
             );
         }).collect(Collectors.toList());

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
@@ -176,6 +176,8 @@ class TravelSearchServiceTest {
                 .userNumber(hostNumber)
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .title(title)
                 .details("여행 내용")
                 .viewCount(viewCount)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelSearchServiceTest.java
@@ -77,19 +77,18 @@ class TravelSearchServiceTest {
         userRepository.deleteAllInBatch();
     }
 
-    @DisplayName("search: 비로그인 사용자도 주어진 검색 조건에 대해 여행 목록을 조회할 수 있다.")
+    @DisplayName("search: 비로그인 사용자는 여행을 검색할 수 있다.")
     @Test
     void searchWhenNotLogin() {
         // given
         Integer hostUserNumber = userRepository.save(createHostUser()).getUserNumber();
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = travelRepository.save(createTravel(
                 hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
         Travel travel2 = travelRepository.save(createTravel(
                 hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
 
         TravelSearchCondition condition = TravelSearchCondition.builder()
                 .pageRequest(PageRequest.of(0, 5))
@@ -101,28 +100,27 @@ class TravelSearchServiceTest {
         // then
         assertThat(result).hasSize(2)
                 .extracting("travelNumber", "title", "location", "userNumber", "userName",
-                        "tags", "nowPerson", "maxPerson", "registerDue", "postStatus", "bookmarked")
+                        "tags", "nowPerson", "maxPerson", "postStatus", "bookmarked")
                 .containsExactly(
+                        tuple(travel2.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, IN_PROGRESS.getName(), false),
                         tuple(travel1.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
-                                List.of(), 0, 0, dueDate, IN_PROGRESS.getName(), false),
-                        tuple(travel2.getNumber(),"여행", "Seoul", hostUserNumber, "주최자명",
-                                List.of(), 0, 0, dueDate.plusDays(1), IN_PROGRESS.getName(), false)
+                                List.of(), 0, 0, IN_PROGRESS.getName(), false)
                 );
     }
 
-    @DisplayName("search: 로그인 사용자는 주어진 검색 조건에 대해 여행 목록을 조회하고 북마크 여부까지 알 수 있다.")
+    @DisplayName("search: 로그인 사용자는 여행을 검색하고 해당 여행에 대한 북마크 여부까지 알 수 있다.")
     @Test
     void search() {
         // given
         Integer hostUserNumber = userRepository.save(createHostUser()).getUserNumber();
         Location location = locationRepository.save(createLocation("Seoul", LocationType.DOMESTIC));
-        LocalDate dueDate = LocalDate.of(2024, 11, 7);
         Travel travel1 = travelRepository.save(createTravel(
                 hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate, PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
         Travel travel2 = travelRepository.save(createTravel(
                 hostUserNumber, location, "여행", 0, 0, GenderType.MIXED,
-                dueDate.plusDays(1), PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
+                PeriodType.ONE_WEEK, IN_PROGRESS, Arrays.asList()));
 
         Map<Integer, Boolean> bookmarkedMap = new HashMap<>();
         bookmarkedMap.put(travel1.getNumber(), true);
@@ -140,15 +138,15 @@ class TravelSearchServiceTest {
 
         // then
         then(bookmarkService).should(times(1))
-                .getBookmarkExistenceByTravelNumbers(10, List.of(travel1.getNumber(), travel2.getNumber()));
+                .getBookmarkExistenceByTravelNumbers(10, List.of(travel2.getNumber(), travel1.getNumber()));
         assertThat(result).hasSize(2)
                 .extracting("travelNumber", "title", "location", "userNumber", "userName",
-                        "tags", "nowPerson", "maxPerson", "registerDue", "postStatus", "bookmarked")
+                        "tags", "nowPerson", "maxPerson", "postStatus", "bookmarked")
                 .containsExactly(
+                        tuple(travel2.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
+                                List.of(), 0, 0, IN_PROGRESS.getName(), false),
                         tuple(travel1.getNumber(), "여행", "Seoul", hostUserNumber, "주최자명",
-                                List.of(), 0, 0, dueDate, IN_PROGRESS.getName(), true),
-                        tuple(travel2.getNumber(),"여행", "Seoul", hostUserNumber, "주최자명",
-                                List.of(), 0, 0, dueDate.plusDays(1), IN_PROGRESS.getName(), false)
+                                List.of(), 0, 0, IN_PROGRESS.getName(), true)
                 );
     }
 
@@ -171,8 +169,8 @@ class TravelSearchServiceTest {
     }
 
     private Travel createTravel(
-            int hostNumber, Location location, String title, int viewCount, int maxPerson, GenderType genderType,
-            LocalDate dueDate, PeriodType periodType, TravelStatus status, List<Tag> tags
+            int hostNumber, Location location, String title, int viewCount, int maxPerson,
+            GenderType genderType, PeriodType periodType, TravelStatus status, List<Tag> tags
     ) {
         return Travel.builder()
                 .userNumber(hostNumber)
@@ -183,7 +181,6 @@ class TravelSearchServiceTest {
                 .viewCount(viewCount)
                 .maxPerson(maxPerson)
                 .genderType(genderType)
-                .dueDate(dueDate)
                 .periodType(periodType)
                 .status(status)
                 .tags(tags)

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelServiceTest.java
@@ -33,7 +33,6 @@ import swyp.swyp6_team7.travel.dto.request.TravelUpdateRequest;
 import swyp.swyp6_team7.travel.dto.response.TravelDetailResponse;
 import swyp.swyp6_team7.travel.repository.TravelRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -82,12 +81,11 @@ class TravelServiceTest {
         userRepository.deleteAllInBatch();
     }
 
-    @DisplayName("create: 여행 콘텐츠를 만들 수 있다")
+    @DisplayName("create: 여행 콘텐츠를 만들 수 있다.")
     @Test
     public void create() {
         // given
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
 
         TravelCreateRequest request = TravelCreateRequest.builder()
                 .locationName("Seoul")
@@ -95,7 +93,6 @@ class TravelServiceTest {
                 .details("여행 내용")
                 .maxPerson(2)
                 .genderType(GenderType.MIXED.toString())
-                .dueDate(dueDate)
                 .periodType(PeriodType.ONE_WEEK.toString())
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -113,7 +110,6 @@ class TravelServiceTest {
         assertThat(createdTravel.getViewCount()).isEqualTo(0);
         assertThat(createdTravel.getMaxPerson()).isEqualTo(2);
         assertThat(createdTravel.getGenderType()).isEqualTo(GenderType.MIXED);
-        assertThat(createdTravel.getDueDate()).isEqualTo(dueDate);
         assertThat(createdTravel.getPeriodType()).isEqualTo(PeriodType.ONE_WEEK);
         assertThat(createdTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
         assertThat(createdTravel.getEnrollmentsLastViewedAt()).isNull();
@@ -130,8 +126,7 @@ class TravelServiceTest {
         String defaultProfileUrl = "https://moing-hosted-contents.s3.ap-northeast-2.amazonaws.com/images/profile/default/defaultProfile.png";
         Users host = userRepository.save(createHostUser());
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(host.getUserNumber(), location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(host.getUserNumber(), location, TravelStatus.IN_PROGRESS));
 
         // when
         TravelDetailResponse travelDetails = travelService.getDetailsByNumber(savedTravel.getNumber());
@@ -151,7 +146,6 @@ class TravelServiceTest {
         assertThat(travelDetails.getNowPerson()).isEqualTo(0);      // 현재 참가자
         assertThat(travelDetails.getMaxPerson()).isEqualTo(2);
         assertThat(travelDetails.getGenderType()).isEqualTo(GenderType.MIXED.toString());
-        assertThat(travelDetails.getDueDate()).isEqualTo(dueDate);
         assertThat(travelDetails.getPeriodType()).isEqualTo(PeriodType.ONE_WEEK.toString());
         assertThat(travelDetails.getTags()).hasSize(1);
         assertThat(travelDetails.getPostStatus()).isEqualTo(TravelStatus.IN_PROGRESS.toString());
@@ -171,15 +165,14 @@ class TravelServiceTest {
                 .hasMessage("해당하는 여행을 찾을 수 없습니다. - travelNumber: " + targetTravelNumber);
     }
 
-    @DisplayName("getDetailsByNumber: 여행 번호가 한 개 주어졌을 때, status가 Deleted인 경우 예외가 발생한다.")
+    @DisplayName("getDetailsByNumber: 여행 번호가 한 개 주어졌을 때, status가 Deleted라면 예외가 발생한다.")
     @Test
     void getDetailsByNumberWhenDeletedStatus() {
         // given
         Users host = userRepository.save(createHostUser());
 
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(host.getUserNumber(), location, dueDate, TravelStatus.DELETED));
+        Travel savedTravel = travelRepository.save(createTravel(host.getUserNumber(), location, TravelStatus.DELETED));
 
         // when // then
         assertThatThrownBy(() -> {
@@ -188,7 +181,7 @@ class TravelServiceTest {
                 .hasMessage("Deleted 상태의 여행 콘텐츠입니다.");
     }
 
-    @DisplayName("getTravelDetailMemberRelatedInfo: 로그인 유저의 여행 상세 조회 요청 시, 필요한 추가 정보를 가져올 수 있다.")
+    @DisplayName("getTravelDetailMemberRelatedInfo: 로그인 유저는 여행 상세 조회 요청 시, 자신과 관련된 상세 정보를 가져올 수 있다.")
     @Test
     void getTravelDetailMemberRelatedInfo() {
         // given
@@ -241,8 +234,7 @@ class TravelServiceTest {
         // given
         int hostUserNumber = 1;
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         TravelUpdateRequest request = TravelUpdateRequest.builder()
                 .locationName("Seoul")
@@ -250,7 +242,6 @@ class TravelServiceTest {
                 .details("여행 내용 수정")
                 .maxPerson(3)
                 .genderType(GenderType.WOMAN_ONLY.toString())
-                .dueDate(LocalDate.of(2024, 11, 5))
                 .periodType(PeriodType.MORE_THAN_MONTH.toString())
                 .tags(List.of("쇼핑"))
                 .completionStatus(true)
@@ -267,7 +258,6 @@ class TravelServiceTest {
         assertThat(updatedTravel.getDetails()).isEqualTo("여행 내용 수정");
         assertThat(updatedTravel.getMaxPerson()).isEqualTo(3);
         assertThat(updatedTravel.getGenderType()).isEqualTo(GenderType.WOMAN_ONLY);
-        assertThat(updatedTravel.getDueDate()).isEqualTo(LocalDate.of(2024, 11, 5));
         assertThat(updatedTravel.getPeriodType()).isEqualTo(PeriodType.MORE_THAN_MONTH);
         assertThat(updatedTravel.getStatus()).isEqualTo(TravelStatus.IN_PROGRESS);
         assertThat(updatedTravel.getTravelTags()).hasSize(1);
@@ -287,8 +277,7 @@ class TravelServiceTest {
         int requestUserNumber = 2;
 
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         TravelUpdateRequest request = TravelUpdateRequest.builder()
                 .tags(List.of())
@@ -308,8 +297,7 @@ class TravelServiceTest {
         // given
         int hostUserNumber = 1;
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         // when
         travelService.delete(savedTravel.getNumber(), hostUserNumber);
@@ -331,8 +319,7 @@ class TravelServiceTest {
         int requestUserNumber = 2;
 
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         // when //then
         assertThatThrownBy(() -> {
@@ -347,8 +334,7 @@ class TravelServiceTest {
         // given
         int hostUserNumber = 1;
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         // when
         LocalDateTime lastViewedAt = travelService.getEnrollmentsLastViewedAt(savedTravel.getNumber());
@@ -363,8 +349,7 @@ class TravelServiceTest {
         // given
         int hostUserNumber = 1;
         Location location = locationRepository.save(createLocation("Seoul"));
-        LocalDate dueDate = LocalDate.of(2024, 11, 4);
-        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, dueDate, TravelStatus.IN_PROGRESS));
+        Travel savedTravel = travelRepository.save(createTravel(hostUserNumber, location, TravelStatus.IN_PROGRESS));
 
         LocalDateTime updateDateTime = LocalDateTime.of(2024, 11, 20, 10, 0);
 
@@ -396,7 +381,7 @@ class TravelServiceTest {
                 .build();
     }
 
-    private Travel createTravel(int hostUserNumber, Location location, LocalDate dueDate, TravelStatus status) {
+    private Travel createTravel(int hostUserNumber, Location location, TravelStatus status) {
         Tag tag1 = tagRepository.save(Tag.of("자연"));
 
         return Travel.builder()
@@ -408,7 +393,6 @@ class TravelServiceTest {
                 .viewCount(0)
                 .maxPerson(2)
                 .genderType(GenderType.MIXED)
-                .dueDate(dueDate)
                 .periodType(PeriodType.ONE_WEEK)
                 .status(status)
                 .tags(List.of(tag1))

--- a/src/test/java/swyp/swyp6_team7/travel/service/TravelViewCountServiceTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/service/TravelViewCountServiceTest.java
@@ -24,6 +24,7 @@ import swyp.swyp6_team7.travel.repository.TravelRepository;
 
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -264,6 +265,8 @@ class TravelViewCountServiceTest {
                 .userNumber(1)
                 .location(location)
                 .locationName(location.getLocationName())
+                .startDate(LocalDate.of(2024, 11, 22))
+                .endDate(LocalDate.of(2024, 11, 28))
                 .title("여행 제목")
                 .details("여행 내용")
                 .viewCount(viewCount)

--- a/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TravelRecommendComparatorTest {
 
-    @DisplayName("compareTo: preferredNumber가 큰 쪽이 더 작다")
+    @DisplayName("compareTo: preferredNumber값이 큰 쪽이 우선 정렬된다.")
     @Test
     public void compareTo() {
         // given
@@ -33,6 +33,7 @@ class TravelRecommendComparatorTest {
         assertThat(result.get(1)).isEqualTo(dto1);
     }
 
+    /*
     @DisplayName("compareTo: preferredNumber가 같으면 RegisterDue가 작은 쪽(현재와 가까운)이 더 작다")
     @Test
     public void compareToWhenPreferredNumberSame() {
@@ -77,6 +78,6 @@ class TravelRecommendComparatorTest {
         // then
         assertThat(result.get(0)).isEqualTo(dto2);
         assertThat(result.get(1)).isEqualTo(dto1);
-    }
+    }*/
 
 }

--- a/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
+++ b/src/test/java/swyp/swyp6_team7/travel/util/TravelRecommendComparatorTest.java
@@ -33,18 +33,17 @@ class TravelRecommendComparatorTest {
         assertThat(result.get(1)).isEqualTo(dto1);
     }
 
-    /*
-    @DisplayName("compareTo: preferredNumber가 같으면 RegisterDue가 작은 쪽(현재와 가까운)이 더 작다")
+    @DisplayName("compareTo: preferredNumber가 같으면 제목순으로 오름차순 정렬한다")
     @Test
-    public void compareToWhenPreferredNumberSame() {
+    public void compareToWhenDueDateSame() {
         // given
         TravelRecommendForMemberDto dto1 = TravelRecommendForMemberDto.builder()
+                .title("나")
                 .preferredNumber(5)
-                .registerDue(LocalDate.now().plusDays(5))
                 .build();
         TravelRecommendForMemberDto dto2 = TravelRecommendForMemberDto.builder()
+                .title("가다")
                 .preferredNumber(5)
-                .registerDue(LocalDate.now().plusDays(1))
                 .build();
         List<TravelRecommendForMemberDto> result = new ArrayList<>(List.of(dto1, dto2));
 
@@ -55,29 +54,5 @@ class TravelRecommendComparatorTest {
         assertThat(result.get(0)).isEqualTo(dto2);
         assertThat(result.get(1)).isEqualTo(dto1);
     }
-
-    @DisplayName("compareTo: preferredNumber, RegisterDue가 같으면 제목순으로 오름차순 정렬한다")
-    @Test
-    public void compareToWhenDueDateSame() {
-        // given
-        TravelRecommendForMemberDto dto1 = TravelRecommendForMemberDto.builder()
-                .title("나")
-                .preferredNumber(5)
-                .registerDue(LocalDate.now().plusDays(5))
-                .build();
-        TravelRecommendForMemberDto dto2 = TravelRecommendForMemberDto.builder()
-                .title("가다")
-                .preferredNumber(5)
-                .registerDue(LocalDate.now().plusDays(5))
-                .build();
-        List<TravelRecommendForMemberDto> result = new ArrayList<>(List.of(dto1, dto2));
-
-        // when
-        Collections.sort(result, new TravelRecommendComparator());
-
-        // then
-        assertThat(result.get(0)).isEqualTo(dto2);
-        assertThat(result.get(1)).isEqualTo(dto1);
-    }*/
 
 }


### PR DESCRIPTION
## 🔗 Issue Number

> 연관된 이슈 번호를 기입해주세요.   
> ex) #이슈번호, #이슈번호

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 테스트 코드 변경 사항
- [ ] 빌드 또는 패키지 매니저 수정
- [ ] 파일 또는 디렉토리 변경 사항

## 📝 작업 내용
요구사항 변경으로 인한 Travel 필드 수정
* 기존: 마감 날짜 dueDate
* 현재: 시작 날짜 startDate, 종료 날짜 endDate
 
관련 로직 수정
* 여행 생성/수정 request에서 dueDate 대신 startDate, endDate 값을 받는다
* 여행 기간이 90일을 초과할 경우 예외가 발생한다
* 여행 조회 계열 API의 response에서 dueDate는 전부 삭제

## 🔖 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## ✅ PR Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
