### PR TITLE
Fix: 로컬 개발 환경 CORS 허용 origin 추가

### DIFF
--- a/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
+++ b/src/main/java/swyp/swyp6_team7/global/config/SecurityConfig.java
@@ -108,7 +108,8 @@ public class SecurityConfig {
                 "https://release-back.vercel.app",
                 "https://www.moing.shop",
                 "https://www.moing.io",
-                "https://www.alpha.moing.io"
+                "https://www.alpha.moing.io",
+                "http://localhost:8080"
         );
 
         CorsConfiguration configuration = new CorsConfiguration();


### PR DESCRIPTION
## 변경 내용

`SecurityConfig.java`의 `corsConfigurationSource()`에 로컬 개발 환경 origin을 추가했습니다.

### 문제
Spring Security의 CORS 설정(`SecurityConfig`)이 `WebMvcConfig`의 CORS 설정을 덮어씁니다.
`SecurityConfig`의 `allowedOrigins`에 `localhost`가 없어서 로컬 개발 중 모든 API 요청이 403으로 차단되었습니다.

### 수정
```java
List<String> allowedOrigins = List.of(
    "https://release-back.vercel.app",
    "https://www.moing.shop",
    "https://www.moing.io",
    "https://www.alpha.moing.io",
    "http://localhost:8080"   // 추가
);
```